### PR TITLE
Data tool layout improvements: mobile spacing & scrollable sidebar

### DIFF
--- a/frontend/src/containers/data-tool/sidebar/index.tsx
+++ b/frontend/src/containers/data-tool/sidebar/index.tsx
@@ -17,7 +17,11 @@ const DataToolSidebar: React.FC = () => {
   const [sidebarOpen, setSidebarOpen] = useState(true);
 
   return (
-    <Collapsible open={sidebarOpen} onOpenChange={setSidebarOpen}>
+    <Collapsible
+      className="h-full overflow-hidden"
+      open={sidebarOpen}
+      onOpenChange={setSidebarOpen}
+    >
       <CollapsibleTrigger asChild>
         <Button
           type="button"
@@ -32,13 +36,15 @@ const DataToolSidebar: React.FC = () => {
           <span className="sr-only">Toggle sidebar</span>
         </Button>
       </CollapsibleTrigger>
-      <CollapsibleContent className="relative top-0 left-0 z-20 h-full w-[430px] flex-shrink-0 bg-white py-4 fill-mode-none data-[state=closed]:animate-out-absolute data-[state=open]:animate-in-absolute data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left">
-        <div className="border-b border-black px-8 py-2">
-          <h1 className="text-5xl font-black">{location.name}</h1>
-          <LocationSelector className="my-2" />
-        </div>
-        <div className="px-8 py-4">
-          <Widgets />
+      <CollapsibleContent className="relative top-0 left-0 z-20 h-full flex-shrink-0 bg-white fill-mode-none data-[state=closed]:animate-out-absolute data-[state=open]:animate-in-absolute data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left md:w-[430px]">
+        <div className="h-full w-full overflow-y-scroll">
+          <div className="border-b border-black px-4 pt-4 pb-2 md:px-8">
+            <h1 className="text-5xl font-black">{location.name}</h1>
+            <LocationSelector className="my-2" />
+          </div>
+          <div className="h-full py-4 px-4 md:px-8">
+            <Widgets />
+          </div>
         </div>
       </CollapsibleContent>
     </Collapsible>

--- a/frontend/src/layouts/data-tool.tsx
+++ b/frontend/src/layouts/data-tool.tsx
@@ -23,7 +23,9 @@ const FullscreenLayout: React.FC<PropsWithChildren<FullscreenLayoutProps>> = ({
       <div className="flex-shrink-0">
         <Header />
       </div>
-      <div className="relative flex h-full w-full flex-col md:flex-row">{children}</div>
+      <div className="relative flex h-full w-full flex-col overflow-hidden md:flex-row">
+        {children}
+      </div>
     </div>
   </>
 );

--- a/frontend/src/pages/data-tool/[locationCode].tsx
+++ b/frontend/src/pages/data-tool/[locationCode].tsx
@@ -36,7 +36,7 @@ export default function Page({ location }: { location: Location }) {
         <Sidebar />
       </div>
       <Content />
-      <div className="h-1/2 flex-shrink-0 overflow-hidden bg-white p-6 pb-3 md:hidden">
+      <div className="h-1/2 flex-shrink-0 overflow-hidden bg-white md:hidden">
         <Sidebar />
       </div>
     </Layout>


### PR DESCRIPTION
This PR improves the data-tool layout: 
- Constrain the display to the windows' dimensions
- Allow the sidebar to scroll
- Fix mobile display


Screenshots: 
![Screenshot 2023-10-24 at 10 23 14](https://github.com/Vizzuality/skytruth-30x30/assets/6273795/c99e2efd-4755-4a25-97bb-d65266657151)
![Screenshot 2023-10-24 at 10 23 06](https://github.com/Vizzuality/skytruth-30x30/assets/6273795/a6700e32-a7b2-4e19-a962-d5335235de73)
