### PR TITLE
Location selector to search by name instead of code/slug

### DIFF
--- a/frontend/src/containers/data-tool/sidebar/location-selector/index.tsx
+++ b/frontend/src/containers/data-tool/sidebar/location-selector/index.tsx
@@ -51,7 +51,7 @@ const LocationSelector: React.FC<LocationSelectorProps> = ({ className }) => {
                 const { name, code, type } = attributes;
 
                 return (
-                  <CommandItem key={code} value={code} onSelect={handleLocationSelected}>
+                  <CommandItem key={code} value={name} onSelect={() => handleLocationSelected(code)}>
                     <div className="flex w-full cursor-pointer justify-between gap-x-4">
                       <div className="flex font-bold underline">
                         <Check


### PR DESCRIPTION
### Overview

This PR fixes a small bug with the location selector; it is currently searching by the location code instead of the actual text.  
The current change seemed to be the easier one to prevent extra work modifying the UI component. 

### Designs

![Screenshot 2023-10-25 at 11 20 55](https://github.com/Vizzuality/skytruth-30x30/assets/6273795/72ee05c8-be5b-4f01-8373-f64832073518)

### Testing instructions

Verify that the Location Selector can search correctly. On staging it is searching by code (eg: `GLOB` triggers worldwide, while searching for `world` does not yield results. )

### Feature relevant tickets

N/A
