### PR TITLE
Permissions for public role to data info endpoints

### DIFF
--- a/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##data-info.data-info.json
+++ b/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##data-info.data-info.json
@@ -111,16 +111,15 @@
       "list": [
         "id",
         "slug",
-        "content"
+        "content",
+        "createdAt"
       ],
       "edit": [
         [
           {
             "name": "slug",
             "size": 6
-          }
-        ],
-        [
+          },
           {
             "name": "content",
             "size": 6

--- a/cms/config/sync/user-role.public.json
+++ b/cms/config/sync/user-role.public.json
@@ -4,6 +4,12 @@
   "type": "public",
   "permissions": [
     {
+      "action": "api::data-info.data-info.find"
+    },
+    {
+      "action": "api::data-info.data-info.findOne"
+    },
+    {
       "action": "api::fishing-protection-level-stat.fishing-protection-level-stat.find"
     },
     {


### PR DESCRIPTION
## Permissions for public role to data info endpoints

### Overview

I forgot to export the permissions when committing the content type.

### Testing instructions

https://30x30.skytruth.org/cms/api/data-infos should not return 403

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/SKY30-81?atlOrigin=eyJpIjoiMTM5YTA0MTYxNDA0NDAzZmI1NjY4NTk3ZmViMDFmZTAiLCJwIjoiaiJ9

---

## Checklist before submitting

- [x] Meaningful commits and code rebased on `develop`.