### PR TITLE
Fix habitat widget bar fill to be relative to total area + changing scale to 100%

### DIFF
--- a/frontend/src/components/charts/horizontal-bar-chart/index.tsx
+++ b/frontend/src/components/charts/horizontal-bar-chart/index.tsx
@@ -5,7 +5,7 @@ import { format } from 'd3-format';
 import { cn } from '@/lib/utils';
 
 const DEFAULT_BAR_COLOR = '#1E1E1E';
-const DEFAULT_MAX_PERCENTAGE = 55;
+const DEFAULT_MAX_PERCENTAGE = 100;
 const PROTECTION_TARGET = 30;
 
 type HorizontalBarChartProps = {

--- a/frontend/src/components/charts/horizontal-bar-chart/index.tsx
+++ b/frontend/src/components/charts/horizontal-bar-chart/index.tsx
@@ -30,7 +30,11 @@ const HorizontalBarChart: React.FC<HorizontalBarChartProps> = ({ className, data
   }, [totalArea, protectedArea]);
 
   const barFillPercentage = useMemo(() => {
-    return Math.round((protectedArea * DEFAULT_MAX_PERCENTAGE) / totalArea);
+    const totalPercentage = (protectedArea * 100) / totalArea;
+    const relativeToMaxPercentage = (totalPercentage * 100) / DEFAULT_MAX_PERCENTAGE;
+
+    // Prevent overflowing if the bar fill exceeds the set max percentage
+    return relativeToMaxPercentage > DEFAULT_MAX_PERCENTAGE ? 100 : relativeToMaxPercentage;
   }, [protectedArea, totalArea]);
 
   const formattedArea = useMemo(() => {


### PR DESCRIPTION
### Overview

**In this PR:**  
- Fix the "bar fill" percentage on the Habitat Widget  
  _During sprint review I noticed that although the displayed percentages are calculated correctly (based on the totalArea, not the target of 30%), the bar fill was incorrect; it was filling in accordance to the target and not the total area. Eg: 84% total area protected, the bar would fill from 0% to 40% of the target of 30%._  
- Set the scale of the chart from 0% to 100% (instead of 0% to 55%)  
  _this is based on the talk during the Sprint review conclusions; that we'll do 100% by now_

**Notes:**
- This widget (and respective chart, which will be used by other widgets) can already handle a variable max percentage to display (55% / 100%) and calculate the display accordingly;  
- The max percentage displayed is currently stored in a `DEFAULT_MAX_PERCENTAGE` constant
  _in antecipation for such a change being needed. The protection target is also in a constant (PROTECTION_TARGET)_
- There was a fail-safe check to ensure a bar won't overflow the chart
  _in case for some reason the data causes the calculations to go over 100%, or in case one of the habitats ends up with a percentage bigger than what the chart can display_

### Screenshots

**Before:**
![scale_bef](https://github.com/Vizzuality/skytruth-30x30/assets/6273795/64a638e5-d04c-4acf-bde0-4909312278ba)

**After:**
![scale_after](https://github.com/Vizzuality/skytruth-30x30/assets/6273795/ddd75c4a-5621-43ca-9d7a-e319e06b48ac)

### Testing instructions

Verify that:  
- The cap on max percentage displayed has changed from 55% to 100%
- The bar respects the percentage displayed  
- The "30% Target" marker adjusts accordingly as well

### Feature relevant tickets

[SKY30-107](https://vizzuality.atlassian.net/browse/SKY30-107) | Fix scale to 100% for the habitat widget


[SKY30-107]: https://vizzuality.atlassian.net/browse/SKY30-107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ