### PR TITLE
Added location geographic bounding box as a JSON field

### DIFF
--- a/cms/config/sync/admin-role.strapi-super-admin.json
+++ b/cms/config/sync/admin-role.strapi-super-admin.json
@@ -330,7 +330,8 @@
           "members",
           "fishing_protection_level_stats",
           "mpaa_protection_level_stats",
-          "protection_coverage_stats"
+          "protection_coverage_stats",
+          "bounds"
         ]
       },
       "conditions": []
@@ -356,7 +357,8 @@
           "members",
           "fishing_protection_level_stats",
           "mpaa_protection_level_stats",
-          "protection_coverage_stats"
+          "protection_coverage_stats",
+          "bounds"
         ]
       },
       "conditions": []
@@ -375,7 +377,8 @@
           "members",
           "fishing_protection_level_stats",
           "mpaa_protection_level_stats",
-          "protection_coverage_stats"
+          "protection_coverage_stats",
+          "bounds"
         ]
       },
       "conditions": []

--- a/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##location.location.json
+++ b/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##location.location.json
@@ -151,6 +151,20 @@
           "sortable": false
         }
       },
+      "bounds": {
+        "edit": {
+          "label": "bounds",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "bounds",
+          "searchable": false,
+          "sortable": false
+        }
+      },
       "createdAt": {
         "edit": {
           "label": "createdAt",
@@ -211,6 +225,14 @@
       }
     },
     "layouts": {
+      "list": [
+        "id",
+        "code",
+        "name",
+        "type",
+        "totalMarineArea",
+        "groups"
+      ],
       "edit": [
         [
           {
@@ -257,15 +279,13 @@
             "name": "protection_coverage_stats",
             "size": 6
           }
+        ],
+        [
+          {
+            "name": "bounds",
+            "size": 12
+          }
         ]
-      ],
-      "list": [
-        "id",
-        "code",
-        "name",
-        "type",
-        "totalMarineArea",
-        "groups"
       ]
     }
   },

--- a/cms/src/api/location/content-types/location/schema.json
+++ b/cms/src/api/location/content-types/location/schema.json
@@ -61,6 +61,9 @@
       "relation": "oneToMany",
       "target": "api::protection-coverage-stat.protection-coverage-stat",
       "mappedBy": "location"
+    },
+    "bounds": {
+      "type": "json"
     }
   }
 }

--- a/cms/types/generated/contentTypes.d.ts
+++ b/cms/types/generated/contentTypes.d.ts
@@ -948,6 +948,7 @@ export interface ApiLocationLocation extends Schema.CollectionType {
       'oneToMany',
       'api::protection-coverage-stat.protection-coverage-stat'
     >;
+    bounds: Attribute.JSON;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     createdBy: Attribute.Relation<


### PR DESCRIPTION
## Added location geographic bounding box as a JSON field

### Overview

Adds `bounds` json field to store location bounds. It's an array of coordinates, e.g.
```
[
    124.3727348,
    32.9104556,
    132.1467806,
    38.623477
],
```

### Testing instructions

It is possible to set bounds for a location.

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/SKY30-84

---

## Checklist before submitting

- [x] Meaningful commits and code rebased on `develop`.