### PR TITLE
SKY30-125 Role for data pipes user

### DIFF
--- a/cms/config/sync/user-role.data_pipes_import_export_access.json
+++ b/cms/config/sync/user-role.data_pipes_import_export_access.json
@@ -1,0 +1,91 @@
+{
+  "name": "Data Pipes Import / Export Access",
+  "description": "Custom role given to users who populate the database from the data pipes through the import / export content API.",
+  "type": "data_pipes_import_export_access",
+  "permissions": [
+    {
+      "action": "api::fishing-protection-level-stat.fishing-protection-level-stat.find"
+    },
+    {
+      "action": "api::fishing-protection-level-stat.fishing-protection-level-stat.findOne"
+    },
+    {
+      "action": "api::fishing-protection-level.fishing-protection-level.find"
+    },
+    {
+      "action": "api::fishing-protection-level.fishing-protection-level.findOne"
+    },
+    {
+      "action": "api::habitat-stat.habitat-stat.find"
+    },
+    {
+      "action": "api::habitat-stat.habitat-stat.findOne"
+    },
+    {
+      "action": "api::habitat.habitat.find"
+    },
+    {
+      "action": "api::habitat.habitat.findOne"
+    },
+    {
+      "action": "api::location.location.find"
+    },
+    {
+      "action": "api::location.location.findOne"
+    },
+    {
+      "action": "api::mpa-protection-coverage-stat.mpa-protection-coverage-stat.find"
+    },
+    {
+      "action": "api::mpa-protection-coverage-stat.mpa-protection-coverage-stat.findOne"
+    },
+    {
+      "action": "api::mpa.mpa.find"
+    },
+    {
+      "action": "api::mpa.mpa.findOne"
+    },
+    {
+      "action": "api::mpaa-establishment-stage-stat.mpaa-establishment-stage-stat.find"
+    },
+    {
+      "action": "api::mpaa-establishment-stage-stat.mpaa-establishment-stage-stat.findOne"
+    },
+    {
+      "action": "api::mpaa-establishment-stage.mpaa-establishment-stage.find"
+    },
+    {
+      "action": "api::mpaa-establishment-stage.mpaa-establishment-stage.findOne"
+    },
+    {
+      "action": "api::mpaa-protection-level-stat.mpaa-protection-level-stat.find"
+    },
+    {
+      "action": "api::mpaa-protection-level-stat.mpaa-protection-level-stat.findOne"
+    },
+    {
+      "action": "api::mpaa-protection-level.mpaa-protection-level.find"
+    },
+    {
+      "action": "api::mpaa-protection-level.mpaa-protection-level.findOne"
+    },
+    {
+      "action": "api::protection-coverage-stat.protection-coverage-stat.find"
+    },
+    {
+      "action": "api::protection-coverage-stat.protection-coverage-stat.findOne"
+    },
+    {
+      "action": "api::protection-status.protection-status.find"
+    },
+    {
+      "action": "api::protection-status.protection-status.findOne"
+    },
+    {
+      "action": "plugin::import-export-entries.export.exportData"
+    },
+    {
+      "action": "plugin::import-export-entries.import.importData"
+    }
+  ]
+}

--- a/cms/config/sync/user-role.public.json
+++ b/cms/config/sync/user-role.public.json
@@ -10,10 +10,34 @@
       "action": "api::data-info.data-info.findOne"
     },
     {
+      "action": "api::data-source.data-source.find"
+    },
+    {
+      "action": "api::data-source.data-source.findOne"
+    },
+    {
+      "action": "api::fishing-protection-level-stat.fishing-protection-level-stat.find"
+    },
+    {
+      "action": "api::fishing-protection-level-stat.fishing-protection-level-stat.findOne"
+    },
+    {
+      "action": "api::fishing-protection-level.fishing-protection-level.find"
+    },
+    {
+      "action": "api::fishing-protection-level.fishing-protection-level.findOne"
+    },
+    {
       "action": "api::habitat-stat.habitat-stat.find"
     },
     {
       "action": "api::habitat-stat.habitat-stat.findOne"
+    },
+    {
+      "action": "api::habitat.habitat.find"
+    },
+    {
+      "action": "api::habitat.habitat.findOne"
     },
     {
       "action": "api::layer.layer.find"
@@ -34,10 +58,46 @@
       "action": "api::mpa-protection-coverage-stat.mpa-protection-coverage-stat.findOne"
     },
     {
+      "action": "api::mpa.mpa.find"
+    },
+    {
+      "action": "api::mpa.mpa.findOne"
+    },
+    {
+      "action": "api::mpaa-establishment-stage-stat.mpaa-establishment-stage-stat.find"
+    },
+    {
+      "action": "api::mpaa-establishment-stage-stat.mpaa-establishment-stage-stat.findOne"
+    },
+    {
+      "action": "api::mpaa-establishment-stage.mpaa-establishment-stage.find"
+    },
+    {
+      "action": "api::mpaa-establishment-stage.mpaa-establishment-stage.findOne"
+    },
+    {
+      "action": "api::mpaa-protection-level-stat.mpaa-protection-level-stat.find"
+    },
+    {
+      "action": "api::mpaa-protection-level-stat.mpaa-protection-level-stat.findOne"
+    },
+    {
+      "action": "api::mpaa-protection-level.mpaa-protection-level.find"
+    },
+    {
+      "action": "api::mpaa-protection-level.mpaa-protection-level.findOne"
+    },
+    {
       "action": "api::protection-coverage-stat.protection-coverage-stat.find"
     },
     {
       "action": "api::protection-coverage-stat.protection-coverage-stat.findOne"
+    },
+    {
+      "action": "api::protection-status.protection-status.find"
+    },
+    {
+      "action": "api::protection-status.protection-status.findOne"
     },
     {
       "action": "plugin::users-permissions.auth.callback"


### PR DESCRIPTION
## Role for data pipes user

### Overview

A new role (Data Pipes Import / Export Access) for authenticated users, with permissions for the import / export content API.

Additionally, restored permissions for Public role.

### Testing instructions

A user with this role will be able to run the import scripts.

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/SKY30-125

---

## Checklist before submitting

- [x] Meaningful commits and code rebased on `develop`.