### PR TITLE
[SKY30-92] Add tooltips to the data tables headers

### DIFF
--- a/frontend/src/containers/data-tool/content/details/table/tooltip-button/index.tsx
+++ b/frontend/src/containers/data-tool/content/details/table/tooltip-button/index.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+
+import { Column } from '@tanstack/react-table';
+import { Info } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { GlobalRegionalTableColumns } from '@/containers/data-tool/content/details/tables/global-regional/useColumns';
+import { NationalHighseasTableColumns } from '@/containers/data-tool/content/details/tables/national-highseas/useColumns';
+
+type TooltipButtonProps = {
+  column:
+    | Column<GlobalRegionalTableColumns, unknown>
+    | Column<NationalHighseasTableColumns, unknown>;
+  tooltips: { [key: string]: string[] };
+};
+
+const TooltipButton: React.FC<TooltipButtonProps> = ({ column, tooltips }) => {
+  const [isTooltipOpen, setIsTooltipOpen] = useState<boolean>(false);
+
+  const tooltip = tooltips[column.id];
+
+  if (!tooltip) return null;
+
+  return (
+    <Popover open={isTooltipOpen} onOpenChange={setIsTooltipOpen}>
+      <PopoverTrigger>
+        <Button className="mt-1 h-auto w-auto pl-2" size="icon" variant="ghost">
+          <span className="sr-only">Info</span>
+          <Info className="h-4 w-4" aria-hidden="true" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="center"
+        className="flex max-w-[300px] flex-col gap-6 font-mono text-xs"
+      >
+        {tooltip}
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export default TooltipButton;

--- a/frontend/src/containers/data-tool/content/details/tables/global-regional/index.tsx
+++ b/frontend/src/containers/data-tool/content/details/tables/global-regional/index.tsx
@@ -2,13 +2,12 @@ import { useMemo, useState } from 'react';
 
 import { useAtomValue } from 'jotai';
 
+import { applyFilters } from '@/containers/data-tool/content/details/helpers';
 import Table from '@/containers/data-tool/content/details/table';
 import useColumns from '@/containers/data-tool/content/details/tables/global-regional/useColumns';
 import { locationAtom } from '@/store/location';
 import { useGetLocations } from '@/types/generated/location';
 import type { LocationListResponseDataItem } from '@/types/generated/strapi.schemas';
-
-import { applyFilters } from '@/containers/data-tool/content/details/helpers';
 
 const DATA_YEAR = 2023;
 

--- a/frontend/src/containers/data-tool/content/details/tables/global-regional/useColumns.tsx
+++ b/frontend/src/containers/data-tool/content/details/tables/global-regional/useColumns.tsx
@@ -6,7 +6,9 @@ import FiltersButton from '@/containers/data-tool/content/details/table/filters-
 import HeaderItem from '@/containers/data-tool/content/details/table/header-item';
 import { cellFormatter } from '@/containers/data-tool/content/details/table/helpers';
 import SortingButton from '@/containers/data-tool/content/details/table/sorting-button';
+import TooltipButton from '@/containers/data-tool/content/details/table/tooltip-button';
 import useFiltersOptions from '@/containers/data-tool/content/details/tables/global-regional/useFiltersOptions';
+import useTooltips from '@/containers/data-tool/content/details/tables/global-regional/useTooltips';
 
 export type GlobalRegionalTableColumns = {
   location: string;
@@ -28,6 +30,8 @@ type UseColumnsProps = {
 const useColumns = ({ filters, onFiltersChange }: UseColumnsProps) => {
   const { locationTypes: locationTypesOptions } = useFiltersOptions();
 
+  const tooltips = useTooltips();
+
   const columns: ColumnDef<GlobalRegionalTableColumns>[] = useMemo(() => {
     return [
       {
@@ -44,6 +48,7 @@ const useColumns = ({ filters, onFiltersChange }: UseColumnsProps) => {
           <HeaderItem>
             <SortingButton column={column} />
             Coverage
+            <TooltipButton column={column} tooltips={tooltips} />
           </HeaderItem>
         ),
         cell: ({ row }) => {
@@ -71,6 +76,7 @@ const useColumns = ({ filters, onFiltersChange }: UseColumnsProps) => {
               onChange={onFiltersChange}
             />
             Location type
+            <TooltipButton column={column} tooltips={tooltips} />
           </HeaderItem>
         ),
         cell: ({ row }) => {
@@ -85,6 +91,7 @@ const useColumns = ({ filters, onFiltersChange }: UseColumnsProps) => {
           <HeaderItem>
             <SortingButton column={column} />
             MPAs
+            <TooltipButton column={column} tooltips={tooltips} />
           </HeaderItem>
         ),
       },
@@ -94,6 +101,7 @@ const useColumns = ({ filters, onFiltersChange }: UseColumnsProps) => {
           <HeaderItem>
             <SortingButton column={column} />
             OECMs
+            <TooltipButton column={column} tooltips={tooltips} />
           </HeaderItem>
         ),
       },
@@ -121,6 +129,7 @@ const useColumns = ({ filters, onFiltersChange }: UseColumnsProps) => {
           <HeaderItem>
             <SortingButton column={column} />
             Fully/Highly Protected
+            <TooltipButton column={column} tooltips={tooltips} />
           </HeaderItem>
         ),
         cell: ({ row }) => {
@@ -136,6 +145,7 @@ const useColumns = ({ filters, onFiltersChange }: UseColumnsProps) => {
           <HeaderItem>
             <SortingButton column={column} />
             Highly Protected LFP
+            <TooltipButton column={column} tooltips={tooltips} />
           </HeaderItem>
         ),
         cell: ({ row }) => {
@@ -151,6 +161,7 @@ const useColumns = ({ filters, onFiltersChange }: UseColumnsProps) => {
           <HeaderItem>
             <SortingButton column={column} />
             Global contribution
+            <TooltipButton column={column} tooltips={tooltips} />
           </HeaderItem>
         ),
         cell: ({ row }) => {

--- a/frontend/src/containers/data-tool/content/details/tables/global-regional/useTooltips.tsx
+++ b/frontend/src/containers/data-tool/content/details/tables/global-regional/useTooltips.tsx
@@ -1,0 +1,37 @@
+import { useGetDataInfos } from '@/types/generated/data-info';
+
+const TOOLTIP_MAPPING = {
+  coverage: 'coverage',
+  locationType: 'location-type',
+  mpas: 'mpas',
+  oecms: 'oecms',
+  fullyHighlyProtected: 'fully-highly-protected',
+  highlyProtectedLfp: 'highly-protected-lfp',
+  globalContribution: 'global-contribution',
+};
+
+const useTooltips = () => {
+  const { data: dataInfo } = useGetDataInfos(
+    {},
+    {
+      query: {
+        select: ({ data }) => data,
+        placeholderData: { data: [] },
+      },
+    }
+  );
+
+  const tooltips = {};
+
+  Object.entries(TOOLTIP_MAPPING).map(([key, value]) => {
+    const tooltip = dataInfo.find(({ attributes }) => attributes.slug === value)?.attributes
+      ?.content;
+
+    if (!tooltip) return;
+    tooltips[key] = tooltip;
+  });
+
+  return tooltips;
+};
+
+export default useTooltips;

--- a/frontend/src/containers/data-tool/content/details/tables/national-highseas/index.tsx
+++ b/frontend/src/containers/data-tool/content/details/tables/national-highseas/index.tsx
@@ -2,12 +2,12 @@ import { useMemo, useState } from 'react';
 
 import { useAtomValue } from 'jotai';
 
+import { applyFilters } from '@/containers/data-tool/content/details/helpers';
 import Table from '@/containers/data-tool/content/details/table';
 import useColumns from '@/containers/data-tool/content/details/tables/national-highseas/useColumns';
 import { locationAtom } from '@/store/location';
 import { useGetMpaProtectionCoverageStats } from '@/types/generated/mpa-protection-coverage-stat';
 import { MpaProtectionCoverageStatListResponseDataItem } from '@/types/generated/strapi.schemas';
-import { applyFilters } from '@/containers/data-tool/content/details/helpers';
 
 const NationalHighseasTable: React.FC = () => {
   const location = useAtomValue(locationAtom);

--- a/frontend/src/containers/data-tool/content/details/tables/national-highseas/useColumns.tsx
+++ b/frontend/src/containers/data-tool/content/details/tables/national-highseas/useColumns.tsx
@@ -6,7 +6,9 @@ import FiltersButton from '@/containers/data-tool/content/details/table/filters-
 import HeaderItem from '@/containers/data-tool/content/details/table/header-item';
 import { cellFormatter } from '@/containers/data-tool/content/details/table/helpers';
 import SortingButton from '@/containers/data-tool/content/details/table/sorting-button';
+import TooltipButton from '@/containers/data-tool/content/details/table/tooltip-button';
 import useFiltersOptions from '@/containers/data-tool/content/details/tables/national-highseas/useFiltersOptions';
+import useTooltips from '@/containers/data-tool/content/details/tables/national-highseas/useTooltips';
 
 export type NationalHighseasTableColumns = {
   protectedArea: string;
@@ -31,6 +33,8 @@ const useColumns = ({ filters, onFiltersChange }: UseColumnsProps) => {
     fishingProtectionLevel: fishingProtectionLevelOptions,
   } = useFiltersOptions();
 
+  const tooltips = useTooltips();
+
   // Define columns
   const columns: ColumnDef<NationalHighseasTableColumns>[] = useMemo(() => {
     return [
@@ -48,6 +52,7 @@ const useColumns = ({ filters, onFiltersChange }: UseColumnsProps) => {
           <HeaderItem>
             <SortingButton column={column} />
             Coverage
+            <TooltipButton column={column} tooltips={tooltips} />
           </HeaderItem>
         ),
         cell: ({ row }) => {
@@ -75,6 +80,7 @@ const useColumns = ({ filters, onFiltersChange }: UseColumnsProps) => {
               onChange={onFiltersChange}
             />
             Protected Area Type
+            <TooltipButton column={column} tooltips={tooltips} />
           </HeaderItem>
         ),
         cell: ({ row }) => {
@@ -96,6 +102,7 @@ const useColumns = ({ filters, onFiltersChange }: UseColumnsProps) => {
               onChange={onFiltersChange}
             />
             Establishment Stage
+            <TooltipButton column={column} tooltips={tooltips} />
           </HeaderItem>
         ),
         cell: ({ row }) => {
@@ -117,6 +124,7 @@ const useColumns = ({ filters, onFiltersChange }: UseColumnsProps) => {
               onChange={onFiltersChange}
             />
             Protection Level
+            <TooltipButton column={column} tooltips={tooltips} />
           </HeaderItem>
         ),
         cell: ({ row }) => {
@@ -138,6 +146,7 @@ const useColumns = ({ filters, onFiltersChange }: UseColumnsProps) => {
               onChange={onFiltersChange}
             />
             Fishing Protection Level
+            <TooltipButton column={column} tooltips={tooltips} />
           </HeaderItem>
         ),
         cell: ({ row }) => {

--- a/frontend/src/containers/data-tool/content/details/tables/national-highseas/useTooltips.tsx
+++ b/frontend/src/containers/data-tool/content/details/tables/national-highseas/useTooltips.tsx
@@ -1,0 +1,35 @@
+import { useGetDataInfos } from '@/types/generated/data-info';
+
+const TOOLTIP_MAPPING = {
+  coverage: 'coverage',
+  protectedAreaType: 'protected-area-type',
+  establishmentStage: 'establishment-stage',
+  protectionLevel: 'protection-level',
+  fishingProtectionLevel: 'fishing-protection-level',
+};
+
+const useTooltips = () => {
+  const { data: dataInfo } = useGetDataInfos(
+    {},
+    {
+      query: {
+        select: ({ data }) => data,
+        placeholderData: { data: [] },
+      },
+    }
+  );
+
+  const tooltips = {};
+
+  Object.entries(TOOLTIP_MAPPING).map(([key, value]) => {
+    const tooltip = dataInfo.find(({ attributes }) => attributes.slug === value)?.attributes
+      ?.content;
+
+    if (!tooltip) return;
+    tooltips[key] = tooltip;
+  });
+
+  return tooltips;
+};
+
+export default useTooltips;


### PR DESCRIPTION
### Overview

This PR adds tooltips to the data table's column headers

**Note:**  
Some things may need to be changed; perhaps on hover instead of click and/or extract the `useTooltips` hooks to a single one, because the widgets will also have tooltips added to them. 

### Feature relevant tickets

[SKY30-92](https://vizzuality.atlassian.net/browse/SKY30-92)

[SKY30-92]: https://vizzuality.atlassian.net/browse/SKY30-92?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ