### PR TITLE
[SKY30-117]: fixes white gap on right side after collapsing sidebar

### DIFF
--- a/frontend/src/containers/data-tool/content/details/index.tsx
+++ b/frontend/src/containers/data-tool/content/details/index.tsx
@@ -39,7 +39,7 @@ const DataToolDetails: React.FC = () => {
           Close
         </Button>
       </div>
-      <div className="overflow-scroll">
+      <div className="overflow-x-auto overflow-y-auto">
         <div className="mt-4">
           <table.component />
         </div>

--- a/frontend/src/containers/data-tool/content/details/table/filters-button/index.tsx
+++ b/frontend/src/containers/data-tool/content/details/table/filters-button/index.tsx
@@ -72,7 +72,7 @@ const FiltersButton: React.FC<FiltersButtonProps> = ({ field, options, values, o
   return (
     <div>
       <Popover open={isFiltersOpen} onOpenChange={setIsFiltersOpen}>
-        <PopoverTrigger>
+        <PopoverTrigger asChild>
           <Button className="-ml-4" size="icon" variant="ghost">
             <span className="sr-only">Filter</span>
             <Filter className={ICON_CLASSNAMES} aria-hidden />

--- a/frontend/src/containers/data-tool/content/details/tables/global-regional/index.tsx
+++ b/frontend/src/containers/data-tool/content/details/tables/global-regional/index.tsx
@@ -2,13 +2,12 @@ import { useMemo, useState } from 'react';
 
 import { useAtomValue } from 'jotai';
 
+import { applyFilters } from '@/containers/data-tool/content/details/helpers';
 import Table from '@/containers/data-tool/content/details/table';
 import useColumns from '@/containers/data-tool/content/details/tables/global-regional/useColumns';
 import { locationAtom } from '@/store/location';
 import { useGetLocations } from '@/types/generated/location';
 import type { LocationListResponseDataItem } from '@/types/generated/strapi.schemas';
-
-import { applyFilters } from '@/containers/data-tool/content/details/helpers';
 
 const DATA_YEAR = 2023;
 

--- a/frontend/src/containers/data-tool/content/details/tables/national-highseas/index.tsx
+++ b/frontend/src/containers/data-tool/content/details/tables/national-highseas/index.tsx
@@ -2,12 +2,12 @@ import { useMemo, useState } from 'react';
 
 import { useAtomValue } from 'jotai';
 
+import { applyFilters } from '@/containers/data-tool/content/details/helpers';
 import Table from '@/containers/data-tool/content/details/table';
 import useColumns from '@/containers/data-tool/content/details/tables/national-highseas/useColumns';
 import { locationAtom } from '@/store/location';
 import { useGetMpaProtectionCoverageStats } from '@/types/generated/mpa-protection-coverage-stat';
 import { MpaProtectionCoverageStatListResponseDataItem } from '@/types/generated/strapi.schemas';
-import { applyFilters } from '@/containers/data-tool/content/details/helpers';
 
 const NationalHighseasTable: React.FC = () => {
   const location = useAtomValue(locationAtom);

--- a/frontend/src/containers/data-tool/content/index.tsx
+++ b/frontend/src/containers/data-tool/content/index.tsx
@@ -7,10 +7,14 @@ const DataToolContent: React.FC = () => {
   const [{ showDetails }] = useSyncDataToolContentSettings();
 
   return (
-    <div className="relative h-full w-full">
+    <>
       <Map />
-      {showDetails && <Details />}
-    </div>
+      {showDetails && (
+        <div className="relative h-full w-full">
+          <Details />
+        </div>
+      )}
+    </>
   );
 };
 


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

This PR removes the white gap in the right side of the screen when the sidebar is collapsed and the map is visible. Also:
- fixes UI hydration warning,
- removes scrollbars of table unless they are needed.

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/SKY30-117

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.