### PR TITLE
Increase max backend CloudRun scale

### DIFF
--- a/infrastructure/base/main.tf
+++ b/infrastructure/base/main.tf
@@ -18,7 +18,7 @@ module "staging" {
   frontend_min_scale  = 0
   backend_min_scale   = 0
   frontend_max_scale  = 1
-  backend_max_scale   = 1
+  backend_max_scale   = 2
   dns_zone_name       = module.dns.dns_zone_name
   domain              = var.domain
   subdomain           = "30x30"

--- a/infrastructure/base/modules/bastion/main.tf
+++ b/infrastructure/base/modules/bastion/main.tf
@@ -23,7 +23,8 @@ resource "google_compute_instance" "bastion" {
   lifecycle {
     ignore_changes = [
       boot_disk,
-      labels
+      labels,
+      metadata # SSH keys added via gcloud compute ssh
     ]
   }
 }


### PR DESCRIPTION
## Increase max backend CloudRun scale

### Overview

In order to try to prevent exceeding rate of requests when running data pipeline scripts, the max scale is now set to 2. The instance still has a cold start to prevent incurring cost when unused.

Added an ignore rule for bastion host metadata to prevent wiping out SSH keys added to the instance by data pipeline users.

---

## Checklist before submitting

- [x] Meaningful commits and code rebased on `develop`.