### PR TITLE
[SKY30-143]: renders EEZ and MAP layers by default

### DIFF
--- a/frontend/src/containers/data-tool/content/map/sync-settings.ts
+++ b/frontend/src/containers/data-tool/content/map/sync-settings.ts
@@ -21,7 +21,7 @@ export const useSyncMapSettings = () => {
 };
 
 export const useSyncMapLayers = () => {
-  return useQueryState('layers', parseAsArrayOf(parseAsInteger).withDefault([]));
+  return useQueryState('layers', parseAsArrayOf(parseAsInteger).withDefault([6, 10]));
 };
 
 export const useSyncMapLayerSettings = () => {


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

This PR loads by default eh EEZ and MAP layers if there are not any other layer set in the URL in the initial load of the page.

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/SKY30-143

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.