### PR TITLE
[N/A]: fixes way to calculate protected area in EEZ popup

### DIFF
--- a/frontend/src/containers/data-tool/sidebar/widgets/marine-conservation/index.tsx
+++ b/frontend/src/containers/data-tool/sidebar/widgets/marine-conservation/index.tsx
@@ -1,6 +1,5 @@
 import { useMemo } from 'react';
 
-import { format } from 'd3-format';
 import { groupBy } from 'lodash-es';
 
 import ConservationChart from '@/components/charts/conservation-chart';
@@ -41,8 +40,7 @@ const MarineConservationWidget: React.FC<MarineConservationWidgetProps> = ({ loc
     {
       ...defaultQueryParams,
       populate: '*',
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
+      // @ts-expect-error this is an issue with Orval typing
       'sort[year]': 'asc',
       'pagination[limit]': -1,
     },
@@ -79,8 +77,13 @@ const MarineConservationWidget: React.FC<MarineConservationWidgetProps> = ({ loc
     const totalArea = location.totalMarineArea;
     const lastYearData = mergedProtectionStats[mergedProtectionStats.length - 1];
     const { protectedArea } = lastYearData;
-    const percentageFormatted = format('.1r')((protectedArea * 100) / totalArea);
-    const totalAreaFormatted = format(',.2r')(totalArea);
+    const formatter = Intl.NumberFormat('en-US', {
+      maximumFractionDigits: 2,
+    });
+    const percentageFormatted = formatter.format((protectedArea / totalArea) * 100);
+    const totalAreaFormatted = Intl.NumberFormat('en-US', {
+      notation: 'standard',
+    }).format(totalArea);
 
     return {
       protectedPercentage: percentageFormatted,
@@ -136,12 +139,15 @@ const MarineConservationWidget: React.FC<MarineConservationWidgetProps> = ({ loc
   return (
     <Widget title="Marine Conservation Coverage" lastUpdated={dataLastUpdate}>
       <div className="mt-6 mb-4 flex flex-col text-blue">
-        <span className="text-5xl font-bold">
-          {stats?.protectedPercentage}
-          <span className="pl-1 text-lg">%</span>
+        <span className="space-x-1">
+          <span className="text-[64px] font-bold leading-[80%]">{stats.protectedPercentage}</span>
+          <span className="text-lg">%</span>
         </span>
-        <span className="text-lg">
-          {stats?.totalArea} km<sup>2</sup>
+        <span className="space-x-1 text-lg  ">
+          <span>{stats.totalArea}</span>
+          <span>
+            km<sup>2</sup>
+          </span>
         </span>
       </div>
       <ConservationChart className="-ml-8 aspect-[16/10]" data={chartData} />


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

- fixes the figure displayed in the EEZ popup to display correctly the same value calculated in the Marine Conservation Coverage widget. 

- fixes formatting of total area.

![image](https://github.com/Vizzuality/skytruth-30x30/assets/999124/5e84e6c8-8737-422e-a10e-8a60880b1d97)




### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

_Link to the related task manager tickets_

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.