### PR TITLE
Fix Marine Conservation Establishment Stages widget bars missing backgrounds

### DIFF
--- a/frontend/src/constants/establishment-stages-chart-bar-backgrounds.ts
+++ b/frontend/src/constants/establishment-stages-chart-bar-backgrounds.ts
@@ -1,7 +1,10 @@
 import { BAR_BACKGROUNDS } from '@/components/charts/horizontal-bar-chart/constants';
 
 export const ESTABLISHMENT_STAGES_CHART_BAR_BACKGROUNDS = {
-  'designated-implemented': 'dots',
-  'designated-unimplemented': 'crosses',
-  'propose-committed': 'arrows',
+  'proposed-committed': 'dots',
+  implemented: 'crosses',
+  designated: 'arrows',
+  unknown: 'dashes',
+  'actively-managed': 'dashes',
+  'designated-unimplemented': 'arrows',
 } satisfies Record<string, keyof typeof BAR_BACKGROUNDS>;


### PR DESCRIPTION
![Screenshot 2023-11-28 at 10 57 17](https://github.com/Vizzuality/skytruth-30x30/assets/6273795/1c7e0bfa-9a09-496f-a57a-37976dfc4ff2)
