### PR TITLE
[N/A] Add CTAs to ToS and Privacy pages

### DIFF
--- a/frontend/src/pages/privacy-policy.tsx
+++ b/frontend/src/pages/privacy-policy.tsx
@@ -1,8 +1,22 @@
+import Cta from '@/components/static-pages/cta';
 import Section from '@/components/static-pages/section';
+import { PAGES } from '@/constants/pages';
 import Layout, { Content } from '@/layouts/static-page';
 
 const PrivacyPolicy: React.FC = () => (
-  <Layout title="Privacy Policy">
+  <Layout
+    title="Privacy Policy"
+    bottom={
+      <Cta
+        title="Take action."
+        description="Do you want to contribute to the Knowledge Hub and add a tool?"
+        button={{
+          text: 'Go to data tool',
+          link: PAGES.dataTool,
+        }}
+      />
+    }
+  >
     <Content>
       <h1 className="text-5xl font-extrabold leading-tight md:text-6xl">Privacy Policy</h1>
       <Section borderTop={false}>

--- a/frontend/src/pages/terms-of-use.tsx
+++ b/frontend/src/pages/terms-of-use.tsx
@@ -1,8 +1,22 @@
+import Cta from '@/components/static-pages/cta';
 import Section from '@/components/static-pages/section';
+import { PAGES } from '@/constants/pages';
 import Layout, { Content } from '@/layouts/static-page';
 
 const PrivacyPolicy: React.FC = () => (
-  <Layout title="Terms of Use">
+  <Layout
+    title="Terms of Use"
+    bottom={
+      <Cta
+        title="Take action."
+        description="Do you want to contribute to the Knowledge Hub and add a tool?"
+        button={{
+          text: 'Go to data tool',
+          link: PAGES.dataTool,
+        }}
+      />
+    }
+  >
     <Content>
       <h1 className="text-5xl font-extrabold leading-tight md:text-6xl">Terms of Use</h1>
       <Section borderTop={false}>


### PR DESCRIPTION
### Overview

This PR adds the shared existing CTAs to the ToS and Privacy Policy pages placeholders. 

### Feature relevant tickets

N/A

### Designs  

(Orange ones)

![Screenshot 2023-11-28 at 16 15 07](https://github.com/Vizzuality/skytruth-30x30/assets/6273795/a8abd8bd-8d68-4cef-aa5c-855a02b002fb)

