### PR TITLE
[N/A] Change tooltip slug for the national/high-seas tables

### DIFF
--- a/frontend/src/containers/data-tool/content/details/tables/national-highseas/useTooltips.tsx
+++ b/frontend/src/containers/data-tool/content/details/tables/national-highseas/useTooltips.tsx
@@ -1,7 +1,7 @@
 import { useGetDataInfos } from '@/types/generated/data-info';
 
 const TOOLTIP_MAPPING = {
-  coverage: 'coverage',
+  coverage: 'coverage-wdpa',
   protectedAreaType: 'protected-area-type',
   establishmentStage: 'establishment-stage',
   protectionLevel: 'protection-level',


### PR DESCRIPTION
### Overview

We need to display different tooltips for the data tables "Coverage" column, depending on whether the user is viewing the global/region table or the national/highseas one. The BE already added the new `coverage-wdpa` slug to the DataInfo table. 

### Feature relevant tickets

N/A
