### PR TITLE
[N/A] Fixing sidebar not showing correctly on Safari

### DIFF
--- a/frontend/src/containers/map/sidebar/index.tsx
+++ b/frontend/src/containers/map/sidebar/index.tsx
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 import { useRouter } from 'next/router';
 
 import { useQueryClient } from '@tanstack/react-query';
+import { VariantProps, cva } from 'class-variance-authority';
 import { useAtom } from 'jotai';
 import { LuChevronLeft, LuChevronRight } from 'react-icons/lu';
 
@@ -18,7 +19,22 @@ import DetailsButton from './details-button';
 import LocationSelector from './location-selector';
 import Widgets from './widgets';
 
-const MapSidebar: React.FC = () => {
+const mapSidebarVariants = cva('', {
+  variants: {
+    layout: {
+      desktop:
+        'absolute data-[state=closed]:animate-out-absolute data-[state=open]:animate-in-absolute data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left',
+      mobile: 'relative',
+    },
+  },
+  defaultVariants: {
+    layout: 'desktop',
+  },
+});
+
+type MapSideBarProps = VariantProps<typeof mapSidebarVariants>;
+
+const MapSidebar: React.FC<MapSideBarProps> = ({ layout }) => {
   const {
     query: { locationCode },
   } = useRouter();
@@ -78,7 +94,12 @@ const MapSidebar: React.FC = () => {
           <span className="sr-only">Toggle sidebar</span>
         </Button>
       </CollapsibleTrigger>
-      <CollapsibleContent className="relative top-0 left-0 z-20 h-full flex-shrink-0 bg-white fill-mode-none data-[state=closed]:animate-out-absolute data-[state=open]:animate-in-absolute data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left md:w-[430px]">
+      <CollapsibleContent
+        className={cn(
+          'top-0 left-0 z-20 h-full flex-shrink-0 bg-white fill-mode-none md:w-[430px]',
+          mapSidebarVariants({ layout })
+        )}
+      >
         <div className="h-full w-full overflow-y-scroll border-x border-black pb-12">
           <div className="border-b border-black px-4 pt-4 pb-2 md:px-8">
             <h1 className="text-5xl font-black">{location?.name}</h1>

--- a/frontend/src/pages/map/[locationCode].tsx
+++ b/frontend/src/pages/map/[locationCode].tsx
@@ -40,11 +40,11 @@ export default function Page({ location }: { location: Location }) {
   return (
     <Layout title={location.name}>
       <div className="hidden md:block">
-        <Sidebar />
+        <Sidebar layout="desktop" />
       </div>
       <Content />
       <div className="h-1/2 flex-shrink-0 overflow-hidden bg-white md:hidden">
-        <Sidebar />
+        <Sidebar layout="mobile" />
       </div>
     </Layout>
   );


### PR DESCRIPTION
### Overview

This PR fixes an issue on Safari/iOS in which the map sidebar doesn't render correctly on the first render.  
It looks like the issue are the animations, which are set for `absolute` positioning, yet the `div` had been set to `relative`. Because the `div` does need to be set to `relative` on mobile, I've added variants. 

**Note:**  
We still have some issues with the height of the app on tablets, due to the top bar; this would be addressed separately. 

### Testing instructions

Using Safari on iOS:  
- Open the website  
- Navigate to the map  
- Verify that:  
  - The sidebar renders correctly
    _See screenshots below for the issue_

### Screenshots

**Before**
![safari-ios-issue](https://github.com/Vizzuality/skytruth-30x30/assets/6273795/78cb09d0-f410-425b-aafd-8b8d0096a0a8)

**After**
![safari-ios-fix](https://github.com/Vizzuality/skytruth-30x30/assets/6273795/d1635dc5-7ec2-4260-9663-a91e503dce11)

### Feature relevant tickets

N/A