### PR TITLE
[N/A] Remove Sidebar animations to decrease issues between browsers

### DIFF
--- a/frontend/src/containers/map/sidebar/index.tsx
+++ b/frontend/src/containers/map/sidebar/index.tsx
@@ -3,7 +3,6 @@ import { useCallback } from 'react';
 import { useRouter } from 'next/router';
 
 import { useQueryClient } from '@tanstack/react-query';
-import { VariantProps, cva } from 'class-variance-authority';
 import { useAtom } from 'jotai';
 import { LuChevronLeft, LuChevronRight } from 'react-icons/lu';
 
@@ -19,22 +18,7 @@ import DetailsButton from './details-button';
 import LocationSelector from './location-selector';
 import Widgets from './widgets';
 
-const mapSidebarVariants = cva('', {
-  variants: {
-    layout: {
-      desktop:
-        'absolute data-[state=closed]:animate-out-absolute data-[state=open]:animate-in-absolute data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left',
-      mobile: 'relative',
-    },
-  },
-  defaultVariants: {
-    layout: 'desktop',
-  },
-});
-
-type MapSideBarProps = VariantProps<typeof mapSidebarVariants>;
-
-const MapSidebar: React.FC<MapSideBarProps> = ({ layout }) => {
+const MapSidebar: React.FC = () => {
   const {
     query: { locationCode },
   } = useRouter();
@@ -94,12 +78,7 @@ const MapSidebar: React.FC<MapSideBarProps> = ({ layout }) => {
           <span className="sr-only">Toggle sidebar</span>
         </Button>
       </CollapsibleTrigger>
-      <CollapsibleContent
-        className={cn(
-          'top-0 left-0 z-20 h-full flex-shrink-0 bg-white fill-mode-none md:w-[430px]',
-          mapSidebarVariants({ layout })
-        )}
-      >
+      <CollapsibleContent className="relative z-20 h-full flex-shrink-0 bg-white fill-mode-none md:w-[430px]">
         <div className="h-full w-full overflow-y-scroll border-x border-black pb-12">
           <div className="border-b border-black px-4 pt-4 pb-2 md:px-8">
             <h1 className="text-5xl font-black">{location?.name}</h1>

--- a/frontend/src/pages/map/[locationCode].tsx
+++ b/frontend/src/pages/map/[locationCode].tsx
@@ -40,11 +40,11 @@ export default function Page({ location }: { location: Location }) {
   return (
     <Layout title={location.name}>
       <div className="hidden md:block">
-        <Sidebar layout="desktop" />
+        <Sidebar />
       </div>
       <Content />
       <div className="h-1/2 flex-shrink-0 overflow-hidden bg-white md:hidden">
-        <Sidebar layout="mobile" />
+        <Sidebar />
       </div>
     </Layout>
   );

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -44,32 +44,10 @@ module.exports = {
           from: { height: 'var(--radix-accordion-content-height)' },
           to: { height: 0 },
         },
-        'in-absolute': {
-          from: {
-            transform:
-              'translate3d(var(--tw-enter-translate-x, 0), var(--tw-enter-translate-y, 0), 0) scale3d(var(--tw-enter-scale, 1), var(--tw-enter-scale, 1), var(--tw-enter-scale, 1)) rotate(var(--tw-enter-rotate, 0))',
-            position: 'absolute',
-          },
-          to: {
-            position: 'absolute',
-          },
-        },
-        'out-absolute': {
-          from: {
-            position: 'absolute',
-          },
-          to: {
-            transform:
-              'translate3d(var(--tw-exit-translate-x, 0), var(--tw-exit-translate-y, 0), 0) scale3d(var(--tw-exit-scale, 1), var(--tw-exit-scale, 1), var(--tw-exit-scale, 1)) rotate(var(--tw-exit-rotate, 0))',
-            position: 'absolute',
-          },
-        },
       },
       animation: {
         'accordion-down': 'accordion-down 0.2s ease-out',
         'accordion-up': 'accordion-up 0.2s ease-out',
-        'in-absolute': 'in-absolute 0.5s ease-out',
-        'out-absolute': 'out-absolute 0.3s ease-out',
       },
     },
   },


### PR DESCRIPTION
### Overview

This PR removes the map sidebar animations, as the positioning is causing issues between browsers.  
As per Slack conversation, quickest way to do this for the MVP is to remove the animations. 

### Feature relevant tickets

N/A - [Slack](https://vizzuality.slack.com/archives/C056QHB3TML/p1701779274698859)
