### PR TITLE
[SKY30-197] Change every instance of the word skytruth to sky truth

### DIFF
--- a/frontend/src/components/footer.tsx
+++ b/frontend/src/components/footer.tsx
@@ -19,7 +19,7 @@ const Footer: React.FC = () => (
             </Link>
           </div>
           <address className="my-4 flex flex-col gap-0.5 pt-6 text-xs not-italic text-black-300 md:my-8">
-            <span>30x30 Skytruth</span>
+            <span>30x30 SkyTruth</span>
             <span>140–142 St No Street, New York, EC1V XXX, US</span>
             <a href="tel:+1 (0)23 0000 0000">+1 (0)23 0000 0000</a>
             <a href="mailto:info@example.com">info@example</a>

--- a/frontend/src/components/head/index.tsx
+++ b/frontend/src/components/head/index.tsx
@@ -1,0 +1,15 @@
+import NextHead from 'next/head';
+
+export type HeadProps = {
+  title?: string;
+  description?: string;
+};
+
+const Head: React.FC<HeadProps> = ({ title, description }) => (
+  <NextHead>
+    <title>{`${title ? `${title} | ` : ''}SkyTruth 30x30`}</title>
+    {description && <meta name="description" content={description} />}
+  </NextHead>
+);
+
+export default Head;

--- a/frontend/src/layouts/default.tsx
+++ b/frontend/src/layouts/default.tsx
@@ -1,8 +1,7 @@
 import { PropsWithChildren } from 'react';
 
-import Head from 'next/head';
-
 import Footer from '@/components/footer';
+import Head from '@/components/head';
 import Header from '@/components/header';
 
 export interface DefaultLayoutProps {
@@ -16,10 +15,7 @@ const DefaultLayout: React.FC<PropsWithChildren<DefaultLayoutProps>> = ({
   description,
 }) => (
   <>
-    <Head>
-      <title>{`${title ? `${title} | ` : ''}SkyTruth 30x30`}</title>
-      {description && <meta name="description" content={description} />}
-    </Head>
+    <Head title={title} description={description} />
     <Header />
     <div className="mx-auto my-8 max-w-7xl px-6 lg:px-10">{children}</div>
     <Footer />

--- a/frontend/src/layouts/default.tsx
+++ b/frontend/src/layouts/default.tsx
@@ -17,7 +17,7 @@ const DefaultLayout: React.FC<PropsWithChildren<DefaultLayoutProps>> = ({
 }) => (
   <>
     <Head>
-      <title>{`${title ? `${title} | ` : ''}Skytruth 30x30`}</title>
+      <title>{`${title ? `${title} | ` : ''}SkyTruth 30x30`}</title>
       {description && <meta name="description" content={description} />}
     </Head>
     <Header />

--- a/frontend/src/layouts/error-page.tsx
+++ b/frontend/src/layouts/error-page.tsx
@@ -19,7 +19,7 @@ const ErrorPageLayout: React.FC<ErrorPageLayoutProps> = ({
 }) => (
   <>
     <Head>
-      <title>{`${pageTitle ? `${pageTitle} | ` : ''}Skytruth 30x30`}</title>
+      <title>{`${pageTitle ? `${pageTitle} | ` : ''}SkyTruth 30x30`}</title>
       {description && <meta name="description" content={description} />}
     </Head>
     <div className="flex h-screen w-full flex-col">

--- a/frontend/src/layouts/error-page.tsx
+++ b/frontend/src/layouts/error-page.tsx
@@ -1,6 +1,6 @@
-import Head from 'next/head';
 import Link from 'next/link';
 
+import Head from '@/components/head';
 import Header from '@/components/header';
 import { PAGES } from '@/constants/pages';
 
@@ -18,10 +18,7 @@ const ErrorPageLayout: React.FC<ErrorPageLayoutProps> = ({
   description,
 }) => (
   <>
-    <Head>
-      <title>{`${pageTitle ? `${pageTitle} | ` : ''}SkyTruth 30x30`}</title>
-      {description && <meta name="description" content={description} />}
-    </Head>
+    <Head title={pageTitle} description={description} />
     <div className="flex h-screen w-full flex-col">
       <div className="flex-shrink-0">
         <Header />

--- a/frontend/src/layouts/fullscreen.tsx
+++ b/frontend/src/layouts/fullscreen.tsx
@@ -1,7 +1,6 @@
 import { PropsWithChildren } from 'react';
 
-import Head from 'next/head';
-
+import Head from '@/components/head';
 import Header from '@/components/header';
 
 export interface FullscreenLayoutProps {
@@ -15,10 +14,7 @@ const FullscreenLayout: React.FC<PropsWithChildren<FullscreenLayoutProps>> = ({
   description,
 }) => (
   <>
-    <Head>
-      <title>{`${title ? `${title} | ` : ''}SkyTruth 30x30`}</title>
-      {description && <meta name="description" content={description} />}
-    </Head>
+    <Head title={title} description={description} />
     <div className="flex h-screen w-full flex-col">
       <div className="flex-shrink-0">
         <Header />

--- a/frontend/src/layouts/fullscreen.tsx
+++ b/frontend/src/layouts/fullscreen.tsx
@@ -16,7 +16,7 @@ const FullscreenLayout: React.FC<PropsWithChildren<FullscreenLayoutProps>> = ({
 }) => (
   <>
     <Head>
-      <title>{`${title ? `${title} | ` : ''}Skytruth 30x30`}</title>
+      <title>{`${title ? `${title} | ` : ''}SkyTruth 30x30`}</title>
       {description && <meta name="description" content={description} />}
     </Head>
     <div className="flex h-screen w-full flex-col">

--- a/frontend/src/layouts/map.tsx
+++ b/frontend/src/layouts/map.tsx
@@ -1,7 +1,6 @@
 import { PropsWithChildren } from 'react';
 
-import Head from 'next/head';
-
+import Head from '@/components/head';
 import Header from '@/components/header';
 
 export interface FullscreenLayoutProps {
@@ -15,10 +14,7 @@ const FullscreenLayout: React.FC<PropsWithChildren<FullscreenLayoutProps>> = ({
   description,
 }) => (
   <>
-    <Head>
-      <title>{`${title ? `${title} | ` : ''}SkyTruth 30x30`}</title>
-      {description && <meta name="description" content={description} />}
-    </Head>
+    <Head title={title} description={description} />
     <div className="flex h-screen w-screen flex-col">
       <div className="flex-shrink-0">
         <Header />

--- a/frontend/src/layouts/map.tsx
+++ b/frontend/src/layouts/map.tsx
@@ -16,7 +16,7 @@ const FullscreenLayout: React.FC<PropsWithChildren<FullscreenLayoutProps>> = ({
 }) => (
   <>
     <Head>
-      <title>{`${title ? `${title} | ` : ''}Skytruth 30x30`}</title>
+      <title>{`${title ? `${title} | ` : ''}SkyTruth 30x30`}</title>
       {description && <meta name="description" content={description} />}
     </Head>
     <div className="flex h-screen w-screen flex-col">

--- a/frontend/src/layouts/static-page.tsx
+++ b/frontend/src/layouts/static-page.tsx
@@ -1,8 +1,7 @@
 import { MutableRefObject, PropsWithChildren, ReactNode } from 'react';
 
-import Head from 'next/head';
-
 import Footer from '@/components/footer';
+import Head from '@/components/head';
 import Header, { HeaderProps } from '@/components/header';
 import Icon from '@/components/ui/icon';
 import { cn } from '@/lib/classnames';
@@ -64,10 +63,7 @@ const StaticPageLayout: React.FC<
   PropsWithChildren<StaticPageLayoutProps & Pick<HeaderProps, 'theme' | 'hideLogo'>>
 > = ({ title, description, hero, bottom, children, theme, hideLogo }) => (
   <>
-    <Head>
-      <title>{`${title ? `${title} | ` : ''}SkyTruth 30x30`}</title>
-      {description && <meta name="description" content={description} />}
-    </Head>
+    <Head title={title} description={description} />
     <div className="flex h-screen w-full flex-col">
       <div className="flex-shrink-0">
         <Header theme={theme} hideLogo={hideLogo} />

--- a/frontend/src/layouts/static-page.tsx
+++ b/frontend/src/layouts/static-page.tsx
@@ -65,7 +65,7 @@ const StaticPageLayout: React.FC<
 > = ({ title, description, hero, bottom, children, theme, hideLogo }) => (
   <>
     <Head>
-      <title>{`${title ? `${title} | ` : ''}Skytruth 30x30`}</title>
+      <title>{`${title ? `${title} | ` : ''}SkyTruth 30x30`}</title>
       {description && <meta name="description" content={description} />}
     </Head>
     <div className="flex h-screen w-full flex-col">


### PR DESCRIPTION
### Overview

This PR changes every instance of the word _Skytruth_ to _SkyTruth_ (notice the capital _T_).  

In order to prevent further typos when creating new pages/layouts, a new `Head` component was added, instead of duplicating the code for every page/layout. 

### Feature relevant tickets

[SKY30-197](https://vizzuality.atlassian.net/browse/SKY30-197)

[SKY30-197]: https://vizzuality.atlassian.net/browse/SKY30-197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ