### PR TITLE
[SKY30-182] Remove '30% target' from the Proportion of Habitat widget

### DIFF
--- a/frontend/src/containers/map/sidebar/details/widgets/habitat/index.tsx
+++ b/frontend/src/containers/map/sidebar/details/widgets/habitat/index.tsx
@@ -84,7 +84,12 @@ const HabitatWidget: React.FC<HabitatWidgetProps> = ({ location }) => {
       loading={loading}
     >
       {widgetChartData.map((chartData) => (
-        <HorizontalBarChart key={chartData.slug} className="py-2" data={chartData} />
+        <HorizontalBarChart
+          key={chartData.slug}
+          className="py-2"
+          data={chartData}
+          showTarget={false}
+        />
       ))}
     </Widget>
   );


### PR DESCRIPTION
### Overview

This PR removes the _30% target_ from the Proportion of Habitat widget. 

### Feature relevant tickets

[SKY30-182](https://vizzuality.atlassian.net/browse/SKY30-182)


[SKY30-182]: https://vizzuality.atlassian.net/browse/SKY30-182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ