### PR TITLE
[SKY30-191] Remove blue bar colors from table rows

### DIFF
--- a/frontend/src/containers/map/content/details/table/index.tsx
+++ b/frontend/src/containers/map/content/details/table/index.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef, useState } from 'react';
+import { useRef } from 'react';
 
 import {
   flexRender,
@@ -14,16 +14,6 @@ const MapTable = ({ columns, data }) => {
   const tableRef = useRef<HTMLTableElement>();
   const firstColumnRef = useRef<HTMLTableCellElement>(null);
 
-  const [tableDimensions, setTableDimensions] = useState<{
-    firstColumnWidth: HTMLTableCellElement['offsetWidth'];
-    tableWidth: HTMLTableElement['offsetWidth'];
-    availableBarWidth: number;
-  }>({
-    firstColumnWidth: 0,
-    tableWidth: 0,
-    availableBarWidth: 0,
-  });
-
   const table = useReactTable<typeof data>({
     data,
     columns,
@@ -35,18 +25,6 @@ const MapTable = ({ columns, data }) => {
 
   const firstColumn = columns[0];
   const lastColumn = columns[columns.length - 1];
-
-  useLayoutEffect(() => {
-    const tableWidth = tableRef.current?.offsetWidth;
-    const firstColumnWidth = firstColumnRef.current?.offsetWidth;
-    const availableBarWidth = tableWidth - firstColumnWidth;
-
-    setTableDimensions({
-      firstColumnWidth,
-      tableWidth,
-      availableBarWidth,
-    });
-  }, [data]);
 
   return (
     <table ref={tableRef} className="whitespace-nowrap font-mono text-xs">
@@ -78,19 +56,8 @@ const MapTable = ({ columns, data }) => {
       <tbody>
         {hasData &&
           table.getRowModel().rows.map((row) => {
-            const coverage = row.original?.coverage || null; // %;
-            const offset = tableDimensions.firstColumnWidth;
-            const barWidth = (coverage * tableDimensions.availableBarWidth) / 100;
-
             return (
-              <tr
-                key={row.id}
-                className="border-b border-t border-black"
-                style={{
-                  backgroundImage: `linear-gradient(to right, rgb(72, 121, 255) ${barWidth}px, transparent ${barWidth}px)`,
-                  backgroundPositionX: `${offset}px`,
-                }}
-              >
+              <tr key={row.id} className="border-b border-t border-black">
                 {row.getVisibleCells().map((cell) => {
                   const { column } = cell;
                   const isFirstColumn = column.id === firstColumn.accessorKey;


### PR DESCRIPTION
### Overview

This PR removes the blue coverage bars from the table rows. 
They do not work correctly on Safari (and possibly Chrome on iOS). A proper fix for this bug (see [example on StackOverflow](https://stackoverflow.com/questions/64912199/safari-table-row-gradient-background-repeat-bug)) was not found in a timely manner, and it was agreed that the course to action would be to simply remove the bars (see feedback sheet)

### Feature relevant tickets

[SKY30-191](https://vizzuality.atlassian.net/browse/SKY30-191)

[SKY30-191]: https://vizzuality.atlassian.net/browse/SKY30-191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ