### PR TITLE
[SKY30-186]: closes popup and fit bounds on opening country insights

### DIFF
--- a/frontend/src/containers/map/content/map/popup/eez/index.tsx
+++ b/frontend/src/containers/map/content/map/popup/eez/index.tsx
@@ -2,14 +2,14 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useMap } from 'react-map-gl';
 
-import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 
 import type { Feature } from 'geojson';
-import { useAtomValue } from 'jotai';
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 
 import { PAGES } from '@/constants/pages';
 import { useMapSearchParams } from '@/containers/map/content/map/sync-settings';
-import { layersInteractiveIdsAtom, popupAtom } from '@/containers/map/store';
+import { bboxLocation, layersInteractiveIdsAtom, popupAtom } from '@/containers/map/store';
 import { useGetLayersId } from '@/types/generated/layer';
 import { useGetLocations } from '@/types/generated/location';
 import { useGetProtectionCoverageStats } from '@/types/generated/protection-coverage-stat';
@@ -21,8 +21,11 @@ const EEZLayerPopup = ({ locationId }) => {
   const DATA_REF = useRef<Feature['properties'] | undefined>();
   const { default: map } = useMap();
   const searchParams = useMapSearchParams();
+  const { push } = useRouter();
+  // @ts-expect-error to work properly, strict mode should be enabled
+  const setLocationBBox = useSetAtom(bboxLocation);
+  const [popup, setPopup] = useAtom(popupAtom);
 
-  const popup = useAtomValue(popupAtom);
   const layersInteractiveIds = useAtomValue(layersInteractiveIdsAtom);
 
   const layerQuery = useGetLayersId(
@@ -112,7 +115,7 @@ const EEZLayerPopup = ({ locationId }) => {
     );
 
   const latestYearAvailable = useMemo(() => {
-    if (protectionCoverageStats) {
+    if (protectionCoverageStats?.[0]) {
       return protectionCoverageStats[0].attributes.year;
     }
   }, [protectionCoverageStats]);
@@ -147,6 +150,12 @@ const EEZLayerPopup = ({ locationId }) => {
   const handleMapRender = useCallback(() => {
     setRendered(map?.loaded() && map?.areTilesLoaded());
   }, [map]);
+
+  const handleLocationSelected = useCallback(async () => {
+    await push(`${PAGES.map}/${locationsQuery.data.code.toUpperCase()}?${searchParams.toString()}`);
+    setLocationBBox(locationsQuery.data.bounds);
+    setPopup({});
+  }, [push, searchParams, setLocationBBox, locationsQuery.data, setPopup]);
 
   useEffect(() => {
     map?.on('render', handleMapRender);
@@ -188,14 +197,13 @@ const EEZLayerPopup = ({ locationId }) => {
               </span>
             </div>
           </div>
-          <Link
-            className="block border border-black p-4 text-center font-mono uppercase"
-            href={`${
-              PAGES.map
-            }/${locationsQuery.data.code.toUpperCase()}?${searchParams.toString()}`}
+          <button
+            type="button"
+            className="block w-full border border-black p-4 text-center font-mono uppercase"
+            onClick={handleLocationSelected}
           >
             Open country insights
-          </Link>
+          </button>
         </>
       )}
     </div>


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

![image](https://github.com/Vizzuality/skytruth-30x30/assets/999124/6fee91c7-827d-4446-b688-983fed06d91d)


Clicking on _Open country insights_ button in popup now fit bounds to the selected location and closes the popup.

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/SKY30-186

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.