### PR TITLE
[SKY30-185] eez popup: changes total area to protected area

### DIFF
--- a/frontend/src/containers/map/content/map/popup/eez/index.tsx
+++ b/frontend/src/containers/map/content/map/popup/eez/index.tsx
@@ -124,13 +124,17 @@ const EEZLayerPopup = ({ locationId }) => {
     return [];
   }, [protectionCoverageStats, latestYearAvailable]);
 
-  const coveragePercentage = useMemo(() => {
-    if (latestProtectionCoverageStats.length && locationsQuery.data) {
-      const totalCumSumProtectedArea = latestProtectionCoverageStats.reduce(
-        (acc, entry) => acc + entry.attributes.cumSumProtectedArea,
-        0
-      );
+  const totalCumSumProtectedArea = useMemo(() => {
+    if (!latestProtectionCoverageStats.length) return 0;
 
+    return latestProtectionCoverageStats.reduce(
+      (acc, entry) => acc + entry.attributes.cumSumProtectedArea,
+      0
+    );
+  }, [latestProtectionCoverageStats]);
+
+  const coveragePercentage = useMemo(() => {
+    if (locationsQuery.data) {
       const formatter = Intl.NumberFormat('en-US', {
         maximumFractionDigits: 0,
       });
@@ -141,7 +145,7 @@ const EEZLayerPopup = ({ locationId }) => {
     }
 
     return '-';
-  }, [latestProtectionCoverageStats, locationsQuery.data]);
+  }, [totalCumSumProtectedArea, locationsQuery.data]);
 
   // handle renderer
   const handleMapRender = useCallback(() => {
@@ -181,7 +185,7 @@ const EEZLayerPopup = ({ locationId }) => {
               <span>
                 {Intl.NumberFormat('en-US', {
                   notation: 'standard',
-                }).format(locationsQuery.data.totalMarineArea)}
+                }).format(totalCumSumProtectedArea)}
               </span>
               <span>
                 km<sup>2</sup>


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

**NOTE: do NOT merge this PR until we have approval from data team.**

### Overview

![image](https://github.com/Vizzuality/skytruth-30x30/assets/999124/539ded06-f699-45be-9d54-3bb027ab8918)


This PR updates the content of the EEZ popup to display the total of protected area instead of the total of marine area.

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/SKY30-185

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.