### PR TITLE
[SKY30-181] Marine Conservation Coverage area should be the protected area, not the total area

### DIFF
--- a/frontend/src/containers/map/content/map/popup/protected-area/index.tsx
+++ b/frontend/src/containers/map/content/map/popup/protected-area/index.tsx
@@ -133,6 +133,9 @@ const ProtectedAreaPopup = ({ locationId }: { locationId: number }) => {
                 {format({
                   value: DATA?.REP_M_AREA,
                   id: 'formatKM',
+                  options: {
+                    maximumSignificantDigits: 3,
+                  },
                 })}
                 Km<sup>2</sup>
               </dd>

--- a/frontend/src/containers/map/sidebar/details/widgets/marine-conservation/index.tsx
+++ b/frontend/src/containers/map/sidebar/details/widgets/marine-conservation/index.tsx
@@ -4,6 +4,7 @@ import { groupBy } from 'lodash-es';
 
 import ConservationChart from '@/components/charts/conservation-chart';
 import Widget from '@/components/widget';
+import { formatKM } from '@/lib/utils/formats';
 import { useGetProtectionCoverageStats } from '@/types/generated/protection-coverage-stat';
 import type { LocationGroupsDataItemAttributes } from '@/types/generated/strapi.schemas';
 
@@ -85,13 +86,11 @@ const MarineConservationWidget: React.FC<MarineConservationWidgetProps> = ({ loc
       maximumFractionDigits: 0,
     });
     const percentageFormatted = formatter.format((protectedArea / totalArea) * 100);
-    const totalAreaFormatted = Intl.NumberFormat('en-US', {
-      notation: 'standard',
-    }).format(totalArea);
+    const protectedAreaFormatted = formatKM(protectedArea);
 
     return {
       protectedPercentage: percentageFormatted,
-      totalArea: totalAreaFormatted,
+      protectedArea: protectedAreaFormatted,
     };
   }, [location, mergedProtectionStats]);
 
@@ -158,7 +157,7 @@ const MarineConservationWidget: React.FC<MarineConservationWidgetProps> = ({ loc
             <span className="text-lg">%</span>
           </span>
           <span className="space-x-1 text-lg  ">
-            <span>{stats?.totalArea}</span>
+            <span>{stats?.protectedArea}</span>
             <span>
               km<sup>2</sup>
             </span>

--- a/frontend/src/lib/utils/formats.ts
+++ b/frontend/src/lib/utils/formats.ts
@@ -14,7 +14,7 @@ export function formatKM(value: number, options?: Intl.NumberFormatOptions) {
     compactDisplay: 'short',
     unit: 'kilometer',
     unitDisplay: 'short',
-    maximumSignificantDigits: 3,
+    maximumFractionDigits: 0,
     ...options,
   });
 


### PR DESCRIPTION
### Overview

**In this PR:**  

The Marine Conservation Coverage widget will now display the protected area instead of the total area. 

**Notes:**
- This widget now uses the `formatKM` helper to display the area  
- `maximumSignificantDigits` was removed from `formatKM` by default, as it was too restrictive. Because this utility was only used in _one_ place in the app, I've added the existing options to the call itself, in order not to change current behaviour. 

### Feature relevant tickets

[SKY30-181](https://vizzuality.atlassian.net/browse/SKY30-181)

[SKY30-181]: https://vizzuality.atlassian.net/browse/SKY30-181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ