### PR TITLE
[SKY30-177] Change the two top line indicators in the homepage to include one decimal place

### DIFF
--- a/frontend/src/containers/homepage/intro/index.tsx
+++ b/frontend/src/containers/homepage/intro/index.tsx
@@ -2,10 +2,9 @@ import { useMemo } from 'react';
 
 import Image from 'next/image';
 
-import { format } from 'd3-format';
-
 import Icon from '@/components/ui/icon';
 import SidebarItem from '@/containers/homepage/intro/sidebar-item';
+import { formatPercentage } from '@/lib/utils/formats';
 import ArrowRight from '@/styles/icons/arrow-right.svg?sprite';
 import { useGetProtectionCoverageStats } from '@/types/generated/protection-coverage-stat';
 
@@ -59,7 +58,7 @@ const Intro: React.FC<IntroProps> = ({ onScrollClick }) => {
 
     if (Number.isNaN(coveragePercentage)) return null;
 
-    return format(',.0r')(coveragePercentage);
+    return formatPercentage(coveragePercentage, { displayPercentageSign: false });
   }, [protectionStatsData]);
 
   return (
@@ -110,7 +109,7 @@ const Intro: React.FC<IntroProps> = ({ onScrollClick }) => {
               icon="icon1"
             />
             <SidebarItem
-              percentage={16}
+              percentage={17.2}
               text="Current global land and inland waters protected area"
               icon="icon2"
             />

--- a/frontend/src/containers/homepage/intro/sidebar-item/index.tsx
+++ b/frontend/src/containers/homepage/intro/sidebar-item/index.tsx
@@ -7,7 +7,7 @@ const ICONS = {
 
 type SidebarItemProps = {
   text: string;
-  percentage: number;
+  percentage: string | number;
   icon?: keyof typeof ICONS;
 };
 


### PR DESCRIPTION
### Important   

This PR is branched off https://github.com/Vizzuality/skytruth-30x30/pull/133 and should not be merged before. 

### Overview

This PR changes the ocean protected area indicator on the homepage intro to have 1 decimal place, as per the feedback sheet, as well as updating the land area indicator which is hardcoded. 

### Feature relevant tickets

[SKY30-177](https://vizzuality.atlassian.net/browse/SKY30-177)

[SKY30-177]: https://vizzuality.atlassian.net/browse/SKY30-177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ