### PR TITLE
[SKY30-203] adds title attribute to display full description mouse hover

### DIFF
--- a/frontend/src/containers/knowledge-hub/card-list/card-item/index.tsx
+++ b/frontend/src/containers/knowledge-hub/card-list/card-item/index.tsx
@@ -22,7 +22,9 @@ const CardItem = ({ data }: { data: DataToolListResponseDataItem }): JSX.Element
           </div>
         )}
         {data.attributes.description && (
-          <p className="line-clamp-5">{data.attributes.description}</p>
+          <p title={data.attributes.description} className="line-clamp-5">
+            {data.attributes.description}
+          </p>
         )}
       </div>
       <div className="mt-5 pt-5">


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

Displays full description of the card (in `/knowledge-hub`) on mouse hover.

![image](https://github.com/Vizzuality/skytruth-30x30/assets/999124/4b6b1d81-7786-4e03-b100-7f96276a262a)


### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/SKY30-203

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.