### PR TITLE
Sky30 180 m 1 use one decimal place in the marine conservation coverage widget fix

### DIFF
--- a/frontend/src/components/charts/horizontal-bar-chart/index.tsx
+++ b/frontend/src/components/charts/horizontal-bar-chart/index.tsx
@@ -54,7 +54,7 @@ const HorizontalBarChart: React.FC<HorizontalBarChartProps> = ({
     <div className={cn('font-mono', className)}>
       <div className="flex items-end justify-end text-3xl font-bold">
         {protectedAreaPercentage}
-        <span className="pb-1.5 pl-1.5 text-xs">%</span>
+        <span className="pb-1.5 pl-1 text-xs">%</span>
       </div>
       <div className="flex justify-between text-xs">
         <span className="flex items-center">

--- a/frontend/src/components/charts/horizontal-bar-chart/index.tsx
+++ b/frontend/src/components/charts/horizontal-bar-chart/index.tsx
@@ -4,6 +4,7 @@ import { format } from 'd3-format';
 
 import TooltipButton from '@/components/tooltip-button';
 import { cn } from '@/lib/classnames';
+import { formatPercentage } from '@/lib/utils/formats';
 
 const DEFAULT_MAX_PERCENTAGE = 100;
 const PROTECTION_TARGET = 30;
@@ -34,12 +35,7 @@ const HorizontalBarChart: React.FC<HorizontalBarChartProps> = ({
   }, []);
 
   const protectedAreaPercentage = useMemo(() => {
-    if (!totalArea || !protectedArea) return format('.0%')(0);
-
-    if (protectedArea / totalArea < 0.01) return format('.3%')(protectedArea / totalArea);
-    if (protectedArea / totalArea < 0.1) return format('.2%')(protectedArea / totalArea);
-
-    return format('.0%')(protectedArea / totalArea);
+    return formatPercentage((protectedArea / totalArea) * 100, { displayPercentageSign: false });
   }, [totalArea, protectedArea]);
 
   const barFillPercentage = useMemo(() => {

--- a/frontend/src/containers/map/content/details/table/helpers.ts
+++ b/frontend/src/containers/map/content/details/table/helpers.ts
@@ -1,7 +1,9 @@
 import { format } from 'd3-format';
 
+import { formatPercentage } from '@/lib/utils/formats';
+
 const percentage = (value: number) => {
-  return format(',.2r')(value) == '0.0' ? '0' : format(',.2r')(value);
+  return formatPercentage(value, { displayPercentageSign: false });
 };
 
 const area = (value: number) => {

--- a/frontend/src/containers/map/content/map/popup/protected-area/index.tsx
+++ b/frontend/src/containers/map/content/map/popup/protected-area/index.tsx
@@ -102,7 +102,7 @@ const ProtectedAreaPopup = ({ locationId }: { locationId: number }) => {
 
   if (!DATA) return null;
 
-  const globalCoverage = DATA.REP_M_AREA / locationQuery.data?.attributes?.totalMarineArea;
+  const globalCoveragePercentage = (DATA.REP_M_AREA / locationQuery.data?.attributes?.totalMarineArea) * 100;
 
   const classNameByMPAType = cn({
     'text-green': DATA?.PA_DEF === '1',
@@ -125,7 +125,7 @@ const ProtectedAreaPopup = ({ locationId }: { locationId: number }) => {
               <dt className={TERMS_CLASSES}>Global coverage</dt>
               <dd className={`font-mono text-6xl tracking-tighter ${classNameByMPAType}`}>
                 {format({
-                  value: globalCoverage,
+                  value: globalCoveragePercentage,
                   id: 'formatPercentage',
                 })}
               </dd>

--- a/frontend/src/containers/map/content/map/popup/protected-area/index.tsx
+++ b/frontend/src/containers/map/content/map/popup/protected-area/index.tsx
@@ -102,7 +102,8 @@ const ProtectedAreaPopup = ({ locationId }: { locationId: number }) => {
 
   if (!DATA) return null;
 
-  const globalCoveragePercentage = (DATA.REP_M_AREA / locationQuery.data?.attributes?.totalMarineArea) * 100;
+  const globalCoveragePercentage =
+    (DATA.REP_M_AREA / locationQuery.data?.attributes?.totalMarineArea) * 100;
 
   const classNameByMPAType = cn({
     'text-green': DATA?.PA_DEF === '1',

--- a/frontend/src/containers/map/sidebar/details/widgets/marine-conservation/index.tsx
+++ b/frontend/src/containers/map/sidebar/details/widgets/marine-conservation/index.tsx
@@ -5,6 +5,7 @@ import { groupBy } from 'lodash-es';
 import ConservationChart from '@/components/charts/conservation-chart';
 import Widget from '@/components/widget';
 import { formatKM } from '@/lib/utils/formats';
+import { formatPercentage } from '@/lib/utils/formats';
 import { useGetProtectionCoverageStats } from '@/types/generated/protection-coverage-stat';
 import type { LocationGroupsDataItemAttributes } from '@/types/generated/strapi.schemas';
 
@@ -82,10 +83,9 @@ const MarineConservationWidget: React.FC<MarineConservationWidgetProps> = ({ loc
     const totalArea = location.totalMarineArea;
     const lastYearData = mergedProtectionStats[mergedProtectionStats.length - 1];
     const { protectedArea } = lastYearData;
-    const formatter = Intl.NumberFormat('en-US', {
-      maximumFractionDigits: 1,
+    const percentageFormatted = formatPercentage((protectedArea / totalArea) * 100, {
+      displayPercentageSign: false,
     });
-    const percentageFormatted = formatter.format((protectedArea / totalArea) * 100);
     const protectedAreaFormatted = formatKM(protectedArea);
 
     return {

--- a/frontend/src/containers/map/sidebar/details/widgets/marine-conservation/index.tsx
+++ b/frontend/src/containers/map/sidebar/details/widgets/marine-conservation/index.tsx
@@ -83,7 +83,7 @@ const MarineConservationWidget: React.FC<MarineConservationWidgetProps> = ({ loc
     const lastYearData = mergedProtectionStats[mergedProtectionStats.length - 1];
     const { protectedArea } = lastYearData;
     const formatter = Intl.NumberFormat('en-US', {
-      maximumFractionDigits: 0,
+      maximumFractionDigits: 1,
     });
     const percentageFormatted = formatter.format((protectedArea / totalArea) * 100);
     const protectedAreaFormatted = formatKM(protectedArea);

--- a/frontend/src/lib/utils/formats.ts
+++ b/frontend/src/lib/utils/formats.ts
@@ -1,11 +1,16 @@
-export function formatPercentage(value: number, options?: Intl.NumberFormatOptions) {
+export function formatPercentage(
+  value: number,
+  options?: Intl.NumberFormatOptions & { displayPercentageSign?: boolean }
+) {
+  const { displayPercentageSign = true, ...intlNumberFormatOptions } = options || {};
+
   const v = Intl.NumberFormat('en-US', {
-    maximumFractionDigits: 3,
-    style: 'percent',
-    ...options,
+    maximumFractionDigits: 1,
+    style: displayPercentageSign ? 'percent' : 'decimal',
+    ...intlNumberFormatOptions,
   });
 
-  return v.format(value);
+  return v.format(displayPercentageSign ? value / 100 : value);
 }
 
 export function formatKM(value: number, options?: Intl.NumberFormatOptions) {

--- a/frontend/src/lib/utils/formats.ts
+++ b/frontend/src/lib/utils/formats.ts
@@ -4,6 +4,10 @@ export function formatPercentage(
 ) {
   const { displayPercentageSign = true, ...intlNumberFormatOptions } = options || {};
 
+  if (value < 0.1 && value > 0) {
+    return displayPercentageSign ? '<0.1%' : '<0.1';
+  }
+
   const v = Intl.NumberFormat('en-US', {
     maximumFractionDigits: 1,
     style: displayPercentageSign ? 'percent' : 'decimal',


### PR DESCRIPTION
This PR aims to fix the issues with https://github.com/Vizzuality/skytruth-30x30/pull/133, which didn't seem to work probably due to a bad rebase. I've opened a new branch and cherry-picked the respective commits. 