### PR TITLE
[SKY30-195] Rework base Contact page layout in order to eliminate screen size issues

### DIFF
--- a/frontend/src/layouts/fullscreen.tsx
+++ b/frontend/src/layouts/fullscreen.tsx
@@ -19,7 +19,9 @@ const FullscreenLayout: React.FC<PropsWithChildren<FullscreenLayoutProps>> = ({
       <div className="flex-shrink-0">
         <Header />
       </div>
-      <div className="h-full border-x border-b border-black">{children}</div>
+      <div className="relative border-x border-b border-black md:h-full md:overflow-hidden">
+        {children}
+      </div>
     </div>
   </>
 );

--- a/frontend/src/pages/contact.tsx
+++ b/frontend/src/pages/contact.tsx
@@ -10,15 +10,20 @@ const ContactUsPage = () => {
       <Script id="hs-script-loader" async defer src="//js.hs-scripts.com/44434484.js"></Script>
       {/* <!-- End of HubSpot Embed Code --> */}
       <Layout title="Contact Us">
-        <div className="px-6 md:mx-auto md:max-w-7xl md:px-6 lg:px-10">
-          <div className="my-8 grid grid-rows-1 gap-10 md:grid-cols-2 md:grid-rows-none">
-            <div className="space-y-2 md:bg-[url('/images/static-pages/bg-images/cta-3.png')] md:bg-left md:bg-no-repeat">
+        <div className="flex h-full flex-col gap-10 px-6 pt-16 md:mx-auto md:max-w-7xl md:flex-row md:gap-20 md:px-6 lg:px-8">
+          <div className="flex flex-col gap-10 md:w-[40%]">
+            <div className="flex flex-grow flex-col gap-3">
               <h2 className="text-[70px] font-black leading-none">
                 Want to <br />
                 know more?
               </h2>
               <h3 className="text-xl font-black">Get it touch.</h3>
             </div>
+            <div className="hidden flex-grow items-end pr-10 md:flex md:h-full">
+              <span className="h-full w-full bg-contain bg-bottom md:bg-[url('/images/static-pages/bg-images/cta-3.png')] md:bg-no-repeat" />
+            </div>
+          </div>
+          <div className="overflow-y-scroll pb-10 md:-mr-4 md:pr-4 md:pl-2">
             <ContactUsForm />
           </div>
         </div>


### PR DESCRIPTION
### Overview

This PR addresses layout issues with the contact page. 

While investigating the ticket, I've noticed a mention about removing the bottom border. However, this border is part of the layout wrapper and not the cause of the visual issues; instead it was due to overflows. 

I've opted to re-implement the base layout for the Contact Page (didn't touch the components), in order to keep things consistent. In this way we approximate the page to the actual designs: 
- The bottom left image is now responsive and stuck to the bottom  
- Minor tweaks to the overall left/right columns spacing  
- Sidebar is now fixed (a requirement in order to keep the bottom left image displayed in a way that matches the designs)  
- Form no longer overflows; instead it is scrollable  
- No issues on mobile, nor in any screen size ranges  

### Designs

[Figma](https://www.figma.com/file/RQB86KnkGg4UTpqQZ09KBX/30x30-Design-%5BInternal%5D?type=design&node-id=610-17111&mode=design)

### Feature relevant tickets

[SKY30-195](https://vizzuality.atlassian.net/browse/SKY30-195)

[SKY30-195]: https://vizzuality.atlassian.net/browse/SKY30-195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ