### PR TITLE
Changed relation between data tool and resource type to has_many

### DIFF
--- a/cms/database/migrations/2024.01.19T10.00.00.change_data_tool_resource_type_relation_to_has_many.js
+++ b/cms/database/migrations/2024.01.19T10.00.00.change_data_tool_resource_type_relation_to_has_many.js
@@ -1,0 +1,18 @@
+module.exports = {
+    async up(knex) {
+        // change the relation from 1:1 to 1:n without losing data
+
+        // add a data_tool_resource_type_order column
+        await knex.schema.table('data_tools_data_tool_resource_type_links', table => {
+            table.integer('data_tool_resource_type_order');
+        });
+        // populate the reorder column with 1
+        await knex.raw('UPDATE data_tools_data_tool_resource_type_links SET data_tool_resource_type_order = 1');
+        // make the column not nullable
+        await knex.schema.alterTable('data_tools_data_tool_resource_type_links', table => {
+            table.integer('data_tool_resource_type_order').notNullable().alter();
+        });
+        // rename the table to match strapi convention
+        await knex.schema.renameTable('data_tools_data_tool_resource_type_links', 'data_tools_data_tool_resource_types_links');
+    },
+}

--- a/cms/src/api/data-tool/content-types/data-tool/schema.json
+++ b/cms/src/api/data-tool/content-types/data-tool/schema.json
@@ -28,9 +28,9 @@
       "target": "api::data-tool-language.data-tool-language",
       "mappedBy": "data_tool"
     },
-    "data_tool_resource_type": {
+    "data_tool_resource_types": {
       "type": "relation",
-      "relation": "oneToOne",
+      "relation": "oneToMany",
       "target": "api::data-tool-resource-type.data-tool-resource-type"
     },
     "geography": {

--- a/cms/types/generated/contentTypes.d.ts
+++ b/cms/types/generated/contentTypes.d.ts
@@ -765,9 +765,9 @@ export interface ApiDataToolDataTool extends Schema.CollectionType {
       'oneToMany',
       'api::data-tool-language.data-tool-language'
     >;
-    data_tool_resource_type: Attribute.Relation<
+    data_tool_resource_types: Attribute.Relation<
       'api::data-tool.data-tool',
-      'oneToOne',
+      'oneToMany',
       'api::data-tool-resource-type.data-tool-resource-type'
     >;
     geography: Attribute.Text;


### PR DESCRIPTION
Changed relation between data tool and resource type to has_many, using a strapi data migration in order not to lose data

---

## Checklist before submitting

- [x] Meaningful commits and code rebased on `develop`.