### PR TITLE
[SKY30-201] Fix details table headers on scroll

### DIFF
--- a/frontend/src/containers/map/content/details/index.tsx
+++ b/frontend/src/containers/map/content/details/index.tsx
@@ -62,8 +62,8 @@ const MapDetails: React.FC = () => {
   }, [locationsQuery.data]);
 
   return (
-    <div className="absolute h-full w-full overflow-x-hidden overflow-y-scroll bg-white px-4 py-4 md:px-6">
-      <div className="mb-8 flex gap-8 md:justify-between">
+    <div className="absolute h-full w-full overflow-scroll bg-white px-4 py-4 md:px-6">
+      <div className="sticky left-0 mb-8 flex gap-8 md:justify-between">
         <span className="max-w-lg">
           <h2 className="text-4xl font-extrabold">{table.title}</h2>
         </span>
@@ -71,10 +71,8 @@ const MapDetails: React.FC = () => {
           Close
         </Button>
       </div>
-      <div className="overflow-x-auto overflow-y-auto">
-        <div className="mt-4">
-          <table.component />
-        </div>
+      <div className="mt-4">
+        <table.component />
       </div>
     </div>
   );

--- a/frontend/src/containers/map/content/details/table/index.tsx
+++ b/frontend/src/containers/map/content/details/table/index.tsx
@@ -24,19 +24,21 @@ const MapTable = ({ columns, data }) => {
   const hasData = table.getRowModel().rows?.length > 0;
 
   const firstColumn = columns[0];
+  const secondColumn = columns[1];
   const lastColumn = columns[columns.length - 1];
 
   return (
     <table
       ref={tableRef}
-      className="relative border-separate border-spacing-0 whitespace-nowrap pr-6 font-mono text-xs"
+      className="relative border-spacing-0 whitespace-nowrap pr-6 font-mono text-xs"
     >
       <thead className="sticky -top-4 z-10 bg-white text-left">
         {table.getHeaderGroups().map((headerGroup) => (
-          <tr key={headerGroup.id}>
+          <tr key={headerGroup.id} className="shadow-[0_2px_0_-1px_rgb(0,0,0)]">
             {headerGroup.headers.map((header) => {
-              const { id, column } = header;
+              const { id, column, index } = header;
               const isFirstColumn = id === firstColumn.accessorKey;
+              const isSecondColumn = index === 1;
               const isLastColumn = id === lastColumn.accessorKey;
 
               return (
@@ -44,8 +46,9 @@ const MapTable = ({ columns, data }) => {
                   key={id}
                   ref={isFirstColumn ? firstColumnRef : null}
                   className={cn({
-                    'h-10 border-b border-black py-3 pl-6 pr-16': true,
-                    'details-table-first-column-border border-black pl-0 pr-5': isFirstColumn,
+                    'h-10 py-3 pl-6 pr-16': true,
+                    'pl-0 pr-5': isFirstColumn,
+                    'border-l border-dashed border-black': isSecondColumn,
                     'pr-0': isLastColumn,
                   })}
                 >
@@ -60,18 +63,26 @@ const MapTable = ({ columns, data }) => {
         {hasData &&
           table.getRowModel().rows.map((row) => {
             return (
-              <tr key={row.id} className="border-b border-t border-black">
+              <tr
+                key={row.id}
+                className={cn({
+                  'border-b border-t border-black': true,
+                  'border-t-0': row.index === 0,
+                })}
+              >
                 {row.getVisibleCells().map((cell) => {
                   const { column } = cell;
                   const isFirstColumn = column.id === firstColumn.accessorKey;
+                  const isSecondColumn = column.id === secondColumn.accessorKey;
                   const isLastColumn = column.id === lastColumn.accessorKey;
 
                   return (
                     <td
                       key={cell.id}
                       className={cn({
-                        'h-16 border-b border-black py-3 pl-6 pr-16': true,
-                        'details-table-first-column-border border-black pl-0 pr-5': isFirstColumn,
+                        'h-16 py-3 pl-6 pr-16': true,
+                        'pl-0 pr-5': isFirstColumn,
+                        'border-l border-dashed border-black': isSecondColumn,
                         'pr-0': isLastColumn,
                       })}
                     >

--- a/frontend/src/containers/map/content/details/table/index.tsx
+++ b/frontend/src/containers/map/content/details/table/index.tsx
@@ -27,8 +27,11 @@ const MapTable = ({ columns, data }) => {
   const lastColumn = columns[columns.length - 1];
 
   return (
-    <table ref={tableRef} className="whitespace-nowrap font-mono text-xs">
-      <thead className="text-left">
+    <table
+      ref={tableRef}
+      className="relative border-separate border-spacing-0 whitespace-nowrap pr-6 font-mono text-xs"
+    >
+      <thead className="sticky -top-4 z-10 bg-white text-left">
         {table.getHeaderGroups().map((headerGroup) => (
           <tr key={headerGroup.id}>
             {headerGroup.headers.map((header) => {
@@ -41,8 +44,8 @@ const MapTable = ({ columns, data }) => {
                   key={id}
                   ref={isFirstColumn ? firstColumnRef : null}
                   className={cn({
-                    'h-10 py-3 pl-6 pr-16': true,
-                    'border-r border-dashed border-black pl-0 pr-5': isFirstColumn,
+                    'h-10 border-b border-black py-3 pl-6 pr-16': true,
+                    'details-table-first-column-border border-black pl-0 pr-5': isFirstColumn,
                     'pr-0': isLastColumn,
                   })}
                 >
@@ -67,8 +70,8 @@ const MapTable = ({ columns, data }) => {
                     <td
                       key={cell.id}
                       className={cn({
-                        'h-16 py-3 pl-6 pr-16': true,
-                        'border-r border-dashed border-black pl-0 pr-5': isFirstColumn,
+                        'h-16 border-b border-black py-3 pl-6 pr-16': true,
+                        'details-table-first-column-border border-black pl-0 pr-5': isFirstColumn,
                         'pr-0': isLastColumn,
                       })}
                     >

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -37,7 +37,3 @@
 .mapboxgl-popup-anchor-left .mapboxgl-popup-tip {
   @apply !border-r-black
 }
-
-.details-table-first-column-border {
-  border-right: 1px dashed;
-}

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -38,3 +38,6 @@
   @apply !border-r-black
 }
 
+.details-table-first-column-border {
+  border-right: 1px dashed;
+}


### PR DESCRIPTION
### Overview

This PR fixes the details tables' header to the top on scroll. 

**Note:** 
It looks like `position: sticky` doesn't play very well when parent containers have an overflow set, so there was some trickery involved in order to make this work. The headers' borders wouldn't display on scroll either, hence the extra global. 

### Feature relevant tickets

[SKY30-201](https://vizzuality.atlassian.net/browse/SKY30-201)

[SKY30-201]: https://vizzuality.atlassian.net/browse/SKY30-201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ