### PR TITLE
[SKY30-189] Prevent the display of percentage values over 100%

### DIFF
--- a/frontend/src/lib/utils/formats.ts
+++ b/frontend/src/lib/utils/formats.ts
@@ -8,6 +8,12 @@ export function formatPercentage(
     return displayPercentageSign ? '<0.1%' : '<0.1';
   }
 
+  // Sanity check to prevent the display of percentages over 100.
+  // This should never be true, but data can be wonky hence this last resort check.
+  if (value > 100) {
+    return displayPercentageSign ? '100%' : '100';
+  }
+
   const v = Intl.NumberFormat('en-US', {
     maximumFractionDigits: 1,
     style: displayPercentageSign ? 'percent' : 'decimal',


### PR DESCRIPTION
### Overview

This PR implements a check when formatting percentages, to prevent the display of values over 100%. 

### Testing instructions

Visit the map, choose "Palau". 
Verify that, on the "Proportion of Habitat within Protected and Conserved Areas" widget, "Seamounts" is not over 100%.

### Feature relevant tickets

[https://vizzuality.atlassian.net/browse/SKY30-189](https://vizzuality.atlassian.net/browse/SKY30-189)