### PR TITLE
[SKY30-223] Make links within info buttons/tooltips clickable

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -65,6 +65,7 @@
     "react-dom": "18.2.0",
     "react-hook-form": "^7.48.2",
     "react-icons": "4.11.0",
+    "react-linkify": "^1.0.0-alpha",
     "react-map-gl": "7.1.6",
     "recharts": "^2.9.0",
     "rooks": "7.14.1",

--- a/frontend/src/components/tooltip-button/index.tsx
+++ b/frontend/src/components/tooltip-button/index.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 
+import Linkify from 'react-linkify';
+
 import { Info } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
@@ -28,7 +30,23 @@ const TooltipButton: React.FC<TooltipButtonProps> = ({ className, text }) => {
         align="center"
         className="flex max-w-[300px] flex-col gap-6 font-mono text-xs"
       >
-        {text}
+        <span>
+          <Linkify
+            componentDecorator={(href, text, key) => (
+              <a
+                className="break-all"
+                href={href}
+                key={key}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {text}
+              </a>
+            )}
+          >
+            {text}
+          </Linkify>
+        </span>
       </PopoverContent>
     </Popover>
   );

--- a/frontend/src/components/tooltip-button/index.tsx
+++ b/frontend/src/components/tooltip-button/index.tsx
@@ -34,7 +34,7 @@ const TooltipButton: React.FC<TooltipButtonProps> = ({ className, text }) => {
           <Linkify
             componentDecorator={(href, text, key) => (
               <a
-                className="break-all"
+                className="break-all underline"
                 href={href}
                 key={key}
                 target="_blank"

--- a/frontend/src/containers/map/content/details/table/tooltip-button/index.tsx
+++ b/frontend/src/containers/map/content/details/table/tooltip-button/index.tsx
@@ -1,8 +1,8 @@
 import { Column } from '@tanstack/react-table';
 
 import TooltipButton from '@/components/tooltip-button';
-import { GlobalRegionalTableColumns } from '@/containers/map/content/details/tables/global-regional/useColumns';
-import { NationalHighseasTableColumns } from '@/containers/map/content/details/tables/national-highseas/useColumns';
+import type { GlobalRegionalTableColumns } from '@/containers/map/content/details/tables/global-regional/useColumns';
+import type { NationalHighseasTableColumns } from '@/containers/map/content/details/tables/national-highseas/useColumns';
 
 type TableTooltipButtonProps = {
   column:

--- a/frontend/src/containers/map/content/details/table/tooltip-button/index.tsx
+++ b/frontend/src/containers/map/content/details/table/tooltip-button/index.tsx
@@ -1,43 +1,18 @@
-import { useState } from 'react';
-
 import { Column } from '@tanstack/react-table';
-import { Info } from 'lucide-react';
 
-import { Button } from '@/components/ui/button';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import TooltipButton from '@/components/tooltip-button';
 import { GlobalRegionalTableColumns } from '@/containers/map/content/details/tables/global-regional/useColumns';
 import { NationalHighseasTableColumns } from '@/containers/map/content/details/tables/national-highseas/useColumns';
 
-type TooltipButtonProps = {
+type TableTooltipButtonProps = {
   column:
     | Column<GlobalRegionalTableColumns, unknown>
     | Column<NationalHighseasTableColumns, unknown>;
-  tooltips: { [key: string]: string[] };
+  tooltips: { [key: string]: string };
 };
 
-const TooltipButton: React.FC<TooltipButtonProps> = ({ column, tooltips }) => {
-  const [isTooltipOpen, setIsTooltipOpen] = useState<boolean>(false);
-
-  const tooltip = tooltips[column.id];
-
-  if (!tooltip) return null;
-
-  return (
-    <Popover open={isTooltipOpen} onOpenChange={setIsTooltipOpen}>
-      <PopoverTrigger asChild>
-        <Button className="h-auto w-auto pl-2" size="icon" variant="ghost">
-          <span className="sr-only">Info</span>
-          <Info className="h-4 w-4" aria-hidden="true" />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent
-        align="center"
-        className="flex max-w-[300px] flex-col gap-6 font-mono text-xs"
-      >
-        {tooltip}
-      </PopoverContent>
-    </Popover>
-  );
+const TableTooltipButton: React.FC<TableTooltipButtonProps> = ({ column, tooltips }) => {
+  return <TooltipButton text={tooltips[column.id]} />;
 };
 
-export default TooltipButton;
+export default TableTooltipButton;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -9197,6 +9197,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"linkify-it@npm:^2.0.3":
+  version: 2.2.0
+  resolution: "linkify-it@npm:2.2.0"
+  dependencies:
+    uc.micro: ^1.0.1
+  checksum: d198871d0b3f3cfdb745dae564bfd6743474f20cd0ef1057e6ca29451834749e7f3da52b59b4de44e98f31a1e5c71bdad160490d4ae54de251cbcde57e4d7837
+  languageName: node
+  linkType: hard
+
 "loader-utils@npm:^1.1.0":
   version: 1.4.2
   resolution: "loader-utils@npm:1.4.2"
@@ -10977,6 +10986,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-linkify@npm:^1.0.0-alpha":
+  version: 1.0.0-alpha
+  resolution: "react-linkify@npm:1.0.0-alpha"
+  dependencies:
+    linkify-it: ^2.0.3
+    tlds: ^1.199.0
+  checksum: abff36e1fdd9db822278292379e070d471d96ddda2d199565edd9ecff3d17faa31a3c83bd2be8fa4c0f9589dd97553ba77c553047b94cfd94e0f528b9e91fafa
+  languageName: node
+  linkType: hard
+
 "react-map-gl@npm:7.1.6":
   version: 7.1.6
   resolution: "react-map-gl@npm:7.1.6"
@@ -11800,6 +11819,7 @@ __metadata:
     react-dom: 18.2.0
     react-hook-form: ^7.48.2
     react-icons: 4.11.0
+    react-linkify: ^1.0.0-alpha
     react-map-gl: 7.1.6
     recharts: ^2.9.0
     rooks: 7.14.1
@@ -12515,6 +12535,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tlds@npm:^1.199.0":
+  version: 1.249.0
+  resolution: "tlds@npm:1.249.0"
+  bin:
+    tlds: bin.js
+  checksum: 66bec7fbe9a87e187691ad10e5e63df4a538adb76b35990efe158c49a6d224ba42a877784149f38a33d38def7e269e22fd494c6b5477358b8e950d6d8532898a
+  languageName: node
+  linkType: hard
+
 "to-object-path@npm:^0.3.0":
   version: 0.3.0
   resolution: "to-object-path@npm:0.3.0"
@@ -12756,6 +12785,13 @@ __metadata:
   dependencies:
     typewise-core: ^1.2.0
   checksum: eb3452b1387df8bf8e3b620720d240425a50ce402d7c064c21ac4b5d88c551ee4d1f26cd649b8a17a6d06f7a3675733de841723f8e06bb3edabfeacc4924af4a
+  languageName: node
+  linkType: hard
+
+"uc.micro@npm:^1.0.1":
+  version: 1.0.6
+  resolution: "uc.micro@npm:1.0.6"
+  checksum: 6898bb556319a38e9cf175e3628689347bd26fec15fc6b29fa38e0045af63075ff3fea4cf1fdba9db46c9f0cbf07f2348cd8844889dd31ebd288c29fe0d27e7a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Overview

This PR makes it so that links within info buttons/tooltips are clickable. 

This applies to:  
  - Widgets / charts tooltips  
  - Table column headers  

This is achieved by the `react-linkify` library. In addition, the details tables' column info buttons now make use of the global tooltip component, so that any related changes to this are applied app-wide. 

### Testing instructions

1. Visit the map page
2. On the _"Marine Conservation Coverage"_
    - Verify the _"30x30 Target"_ Info button's link is clickable
3. On the _"Marine Conservation Protection Levels"_ bar charts
    - Verify the info buttons' links are clickable
4. Open the details' table
    - Verify that links are clickable in the table column headers' info buttons 

### Feature relevant tickets

[SKY30-223](https://vizzuality.atlassian.net/browse/SKY30-223)

[SKY30-223]: https://vizzuality.atlassian.net/browse/SKY30-223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ