### PR TITLE
[SKY30-224] Add links to data partners logos in the about section

### DIFF
--- a/frontend/src/containers/about/logo/constants.ts
+++ b/frontend/src/containers/about/logo/constants.ts
@@ -6,17 +6,20 @@ export const LOGOS = {
   protectedPlanet: {
     logo: 'protected-planet.png',
     alt: 'Protected Planet logo',
+    link: 'https://www.protectedplanet.net',
     width: 237,
     height: 84,
   },
   marineProtectionAtlas: {
     logo: 'mpa.png',
     alt: 'Marine Protection Atlas logo',
+    link: 'https://mpatlas.org',
     width: 224,
     height: 132,
   },
   protectedSeas: {
     logo: 'protected-seas.png',
+    link: 'https://protectedseas.net',
     alt: 'Protected Seas logo',
     width: 251,
     height: 95,

--- a/frontend/src/containers/about/logo/index.tsx
+++ b/frontend/src/containers/about/logo/index.tsx
@@ -7,11 +7,20 @@ type LogoProps = {
 };
 
 const Logo: React.FC<LogoProps> = ({ logo: logoKey }) => {
-  const { logo, alt, width, height } = LOGOS[logoKey];
+  const { logo, link, alt, width, height } = LOGOS[logoKey];
 
   return (
     <span>
-      <Image src={`${LOGOS_PATH}${logo}`} alt={alt} width={width} height={height} />
+      {link && (
+        <a target="_blank" href={link} rel="noopener noreferrer">
+          <Image src={`${LOGOS_PATH}${logo}`} alt={alt} width={width} height={height} />
+        </a>
+      )}
+      {!link && (
+        <span>
+          <Image src={`${LOGOS_PATH}${logo}`} alt={alt} width={width} height={height} />
+        </span>
+      )}
     </span>
   );
 };

--- a/frontend/src/containers/about/logo/types.ts
+++ b/frontend/src/containers/about/logo/types.ts
@@ -3,6 +3,7 @@ import { ImageProps } from 'next/image';
 export type LogoType = Pick<ImageProps, 'alt' | 'width' | 'height'> & {
   logo: string;
   alt: string;
+  link: string;
 };
 
 export type LogosType = {


### PR DESCRIPTION
### Overview

This PR adds links to the logos in the _"Who are our data partners?"_ section of the about page. 

### Testing instructions

Visit the about page and verify that the logos under the _"Who are our data partners?"_ section are linked to the respective websites.

### Feature relevant tickets

[SKY30-224](https://vizzuality.atlassian.net/browse/SKY30-224)