### PR TITLE
[SKY30-227] Check regions tooltip (area and decimals in %)

### DIFF
--- a/frontend/src/containers/map/content/map/popup/eez/index.tsx
+++ b/frontend/src/containers/map/content/map/popup/eez/index.tsx
@@ -10,7 +10,7 @@ import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { PAGES } from '@/constants/pages';
 import { useMapSearchParams } from '@/containers/map/content/map/sync-settings';
 import { bboxLocation, layersInteractiveIdsAtom, popupAtom } from '@/containers/map/store';
-import { formatPercentage } from '@/lib/utils/formats';
+import { formatPercentage, formatKM } from '@/lib/utils/formats';
 import { useGetLayersId } from '@/types/generated/layer';
 import { useGetLocations } from '@/types/generated/location';
 import { useGetProtectionCoverageStats } from '@/types/generated/protection-coverage-stat';
@@ -191,11 +191,7 @@ const EEZLayerPopup = ({ locationId }) => {
               {coveragePercentage !== '-' && <span className="text-lg">%</span>}
             </div>
             <div className="space-x-1 font-mono text-xl text-blue">
-              <span>
-                {Intl.NumberFormat('en-US', {
-                  notation: 'standard',
-                }).format(totalCumSumProtectedArea)}
-              </span>
+              <span>{formatKM(totalCumSumProtectedArea)}</span>
               <span>
                 km<sup>2</sup>
               </span>

--- a/frontend/src/containers/map/content/map/popup/eez/index.tsx
+++ b/frontend/src/containers/map/content/map/popup/eez/index.tsx
@@ -10,6 +10,7 @@ import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { PAGES } from '@/constants/pages';
 import { useMapSearchParams } from '@/containers/map/content/map/sync-settings';
 import { bboxLocation, layersInteractiveIdsAtom, popupAtom } from '@/containers/map/store';
+import { formatPercentage } from '@/lib/utils/formats';
 import { useGetLayersId } from '@/types/generated/layer';
 import { useGetLocations } from '@/types/generated/location';
 import { useGetProtectionCoverageStats } from '@/types/generated/protection-coverage-stat';
@@ -138,12 +139,11 @@ const EEZLayerPopup = ({ locationId }) => {
 
   const coveragePercentage = useMemo(() => {
     if (locationsQuery.data) {
-      const formatter = Intl.NumberFormat('en-US', {
-        maximumFractionDigits: 0,
-      });
-
-      return formatter.format(
-        (totalCumSumProtectedArea / locationsQuery.data.totalMarineArea) * 100
+      return formatPercentage(
+        (totalCumSumProtectedArea / locationsQuery.data.totalMarineArea) * 100,
+        {
+          displayPercentageSign: false,
+        }
       );
     }
 

--- a/frontend/src/containers/map/content/map/popup/regions/index.tsx
+++ b/frontend/src/containers/map/content/map/popup/regions/index.tsx
@@ -10,6 +10,7 @@ import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { PAGES } from '@/constants/pages';
 import { useMapSearchParams } from '@/containers/map/content/map/sync-settings';
 import { bboxLocation, layersInteractiveIdsAtom, popupAtom } from '@/containers/map/store';
+import { formatPercentage } from '@/lib/utils/formats';
 import { useGetLayersId } from '@/types/generated/layer';
 import { useGetLocations } from '@/types/generated/location';
 import { useGetProtectionCoverageStats } from '@/types/generated/protection-coverage-stat';
@@ -135,12 +136,11 @@ const EEZLayerPopup = ({ locationId }) => {
         0
       );
 
-      const formatter = Intl.NumberFormat('en-US', {
-        maximumFractionDigits: 2,
-      });
-
-      return formatter.format(
-        (totalCumSumProtectedArea / locationsQuery.data.totalMarineArea) * 100
+      return formatPercentage(
+        (totalCumSumProtectedArea / locationsQuery.data.totalMarineArea) * 100,
+        {
+          displayPercentageSign: false,
+        }
       );
     }
 

--- a/frontend/src/containers/map/content/map/popup/regions/index.tsx
+++ b/frontend/src/containers/map/content/map/popup/regions/index.tsx
@@ -211,7 +211,7 @@ const EEZLayerPopup = ({ locationId }) => {
             className="block w-full border border-black p-4 text-center font-mono uppercase"
             onClick={handleLocationSelected}
           >
-            Open country insights
+            Open region insights
           </button>
         </>
       )}

--- a/frontend/src/containers/map/content/map/popup/regions/index.tsx
+++ b/frontend/src/containers/map/content/map/popup/regions/index.tsx
@@ -10,7 +10,7 @@ import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { PAGES } from '@/constants/pages';
 import { useMapSearchParams } from '@/containers/map/content/map/sync-settings';
 import { bboxLocation, layersInteractiveIdsAtom, popupAtom } from '@/containers/map/store';
-import { formatPercentage } from '@/lib/utils/formats';
+import { formatPercentage, formatKM } from '@/lib/utils/formats';
 import { useGetLayersId } from '@/types/generated/layer';
 import { useGetLocations } from '@/types/generated/location';
 import { useGetProtectionCoverageStats } from '@/types/generated/protection-coverage-stat';
@@ -188,11 +188,7 @@ const EEZLayerPopup = ({ locationId }) => {
               {coveragePercentage !== '-' && <span className="text-lg">%</span>}
             </div>
             <div className="space-x-1 font-mono text-xl text-blue">
-              <span>
-                {Intl.NumberFormat('en-US', {
-                  notation: 'standard',
-                }).format(locationsQuery.data.totalMarineArea)}
-              </span>
+              <span>{formatKM(locationsQuery.data.totalMarineArea)}</span>
               <span>
                 km<sup>2</sup>
               </span>

--- a/frontend/src/containers/map/content/map/popup/regions/index.tsx
+++ b/frontend/src/containers/map/content/map/popup/regions/index.tsx
@@ -129,22 +129,32 @@ const EEZLayerPopup = ({ locationId }) => {
     return [];
   }, [protectionCoverageStats, latestYearAvailable]);
 
-  const coveragePercentage = useMemo(() => {
+  const coverageStats = useMemo(() => {
     if (latestProtectionCoverageStats.length && locationsQuery.data) {
       const totalCumSumProtectedArea = latestProtectionCoverageStats.reduce(
         (acc, entry) => acc + entry.attributes.cumSumProtectedArea,
         0
       );
 
-      return formatPercentage(
+      const percentage = formatPercentage(
         (totalCumSumProtectedArea / locationsQuery.data.totalMarineArea) * 100,
         {
           displayPercentageSign: false,
         }
       );
+
+      const protectedArea = formatKM(totalCumSumProtectedArea);
+
+      return {
+        percentage,
+        protectedArea,
+      };
     }
 
-    return '-';
+    return {
+      percentage: '-',
+      protectedArea: '-',
+    };
   }, [latestProtectionCoverageStats, locationsQuery.data]);
 
   // handle renderer
@@ -184,11 +194,13 @@ const EEZLayerPopup = ({ locationId }) => {
           <div className="space-y-2">
             <div className="font-mono uppercase">Marine conservation coverage</div>
             <div className="space-x-1 font-mono tracking-tighter text-blue">
-              <span className="text-[64px] font-bold leading-[80%]">{coveragePercentage}</span>
-              {coveragePercentage !== '-' && <span className="text-lg">%</span>}
+              <span className="text-[64px] font-bold leading-[80%]">
+                {coverageStats.percentage}
+              </span>
+              {coverageStats.percentage !== '-' && <span className="text-lg">%</span>}
             </div>
             <div className="space-x-1 font-mono text-xl text-blue">
-              <span>{formatKM(locationsQuery.data.totalMarineArea)}</span>
+              <span>{coverageStats.protectedArea}</span>
               <span>
                 km<sup>2</sup>
               </span>


### PR DESCRIPTION
### Overview

This PR fixes a couple issues in which the region popup percentage formatting does not match the formatting in the sidebar. In addition, it switches the area displayed to be the protected area, not the total one. 

**In this PR:**
- Use the `formatPercentage` and `formatKM` helpers in both _Regions_ and _EEZ_ popups, in order to keep the formatting consistent  
- Map regions tooltip now displays the protected area, not the total area
  _Similar calculations as the ones used in the sidebar_  
- Changed the Regions tooltip button to say _Open region insights_ instead of _Open country insights_

### Testing instructions

1. Visit the map  
2. Choose _"Africa"_ region  
3. On the map, toggle all layers off except for the _"Regions"_ one  
4. Click on the highlighted Africa region on the map  
    - Verify that the area and percentage formatting match the ones shown on the sidebar

### Feature relevant tickets

[SKY30-227](https://vizzuality.atlassian.net/browse/SKY30-227)

[SKY30-227]: https://vizzuality.atlassian.net/browse/SKY30-227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ