### PR TITLE
[SKY30-228] M3 - Adapt dashboard to new design

### DIFF
--- a/frontend/src/containers/map/sidebar/details/widgets/index.tsx
+++ b/frontend/src/containers/map/sidebar/details/widgets/index.tsx
@@ -4,7 +4,7 @@ import { useSyncMapContentSettings } from '@/containers/map/sync-settings';
 import { cn } from '@/lib/classnames';
 import { useGetLocations } from '@/types/generated/location';
 
-import EstablishmentStagesWidget from './establishment-stages';
+// import EstablishmentStagesWidget from './establishment-stages';
 import HabitatWidget from './habitat';
 import MarineConservationWidget from './marine-conservation';
 import ProtectionTypesWidget from './protection-types';
@@ -31,7 +31,7 @@ const DetailsWidgets: React.FC = () => {
     >
       <MarineConservationWidget location={locationsData?.data[0]?.attributes} />
       <ProtectionTypesWidget location={locationsData?.data[0]?.attributes} />
-      <EstablishmentStagesWidget location={locationsData?.data[0]?.attributes} />
+      {/* <EstablishmentStagesWidget location={locationsData?.data[0]?.attributes} /> */}
       <HabitatWidget location={locationsData?.data[0]?.attributes} />
     </div>
   );


### PR DESCRIPTION
### Overview

Ongoing work to adapt the dashboard to the new designs. 

Changes intended:  
- ~Add the new bar for the Fishing protection indicator~
  _Note: There's a task [specific to this change](https://vizzuality.atlassian.net/browse/SKY30-226), so it won't be addressed by this PR_  
- Remove the Marine Conservation Establishment Stages widget
  _Not intended to be in the Sidebar at this point; it's been commented out so we retain its code for a future stage_  
- ~Remove the 30% Target only in the _Proportion of Habitat within Protected and Conserved Areas_ widget~  
  _Technically not addressed in this PR; it's been removed before. _

### Feature relevant tickets

[SKY30-228](https://vizzuality.atlassian.net/browse/SKY30-228)

[SKY30-228]: https://vizzuality.atlassian.net/browse/SKY30-228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ