### PR TITLE
[SKY30-239] Change change location and close dashboard buttons font

### DIFF
--- a/frontend/src/containers/map/content/details/index.tsx
+++ b/frontend/src/containers/map/content/details/index.tsx
@@ -67,7 +67,11 @@ const MapDetails: React.FC = () => {
         <span className="max-w-lg">
           <h2 className="text-4xl font-extrabold">{table.title}</h2>
         </span>
-        <Button variant="text-link" className="m-0 cursor-pointer p-0" onClick={handleOnCloseClick}>
+        <Button
+          variant="text-link"
+          className="m-0 cursor-pointer p-0 font-mono text-xs"
+          onClick={handleOnCloseClick}
+        >
           Close
         </Button>
       </div>

--- a/frontend/src/containers/map/sidebar/details/location-selector/index.tsx
+++ b/frontend/src/containers/map/sidebar/details/location-selector/index.tsx
@@ -84,7 +84,7 @@ const LocationSelector: React.FC<LocationSelectorProps> = ({ className }) => {
   return (
     <div className={cn(className)}>
       <Popover open={locationPopoverOpen} onOpenChange={setLocationPopoverOpen}>
-        <PopoverTrigger className="text-sm font-semibold uppercase underline ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black focus-visible:ring-offset-2">
+        <PopoverTrigger className="font-mono text-xs font-semibold uppercase underline ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black focus-visible:ring-offset-2">
           Change Location
         </PopoverTrigger>
         <PopoverContent className="w-96 max-w-screen" align="start">


### PR DESCRIPTION
### Overview

This PR changes the dashboard's _"Change location"_ and details' _"Close"_ button font to overpass mono to match the rest of the website. In addition, the text size was better approximated to the designs. 

### Feature relevant tickets

[SKY30-239](https://vizzuality.atlassian.net/browse/SKY30-239)

[SKY30-239]: https://vizzuality.atlassian.net/browse/SKY30-239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ