### PR TITLE
[SKY30-226] Add highly protected from fishing indicator to the Marine Conservation Protection Levels widget

### DIFF
--- a/frontend/src/constants/protection-types-chart-colors.ts
+++ b/frontend/src/constants/protection-types-chart-colors.ts
@@ -1,4 +1,4 @@
 export const PROTECTION_TYPES_CHART_COLORS = {
   'fully-highly-protected': '#FD8E28',
-  'less-protected-unknown': '#FFDD88',
+  highly: '#D9635C',
 };

--- a/frontend/src/containers/map/sidebar/details/widgets/protection-types/index.tsx
+++ b/frontend/src/containers/map/sidebar/details/widgets/protection-types/index.tsx
@@ -38,8 +38,8 @@ const ProtectionTypesWidget: React.FC<ProtectionTypesWidgetProps> = ({ location 
 
   // Get fully or highly protected
   const {
-    data: { data: protectionLevelStatsData },
-    isFetching: isFetchingProtectionStatsData,
+    data: { data: mpaaProtectionLevelStatsData },
+    isFetching: isFetchingMpaaProtectionStatsData,
   } = useGetMpaaProtectionLevelStats(
     {
       filters: {
@@ -86,40 +86,36 @@ const ProtectionTypesWidget: React.FC<ProtectionTypesWidgetProps> = ({ location 
 
   // Parse data to display in the chart
   const widgetChartData = useMemo(() => {
-    const parsedMpaaProtectionLevelData = protectionLevelStatsData.map((entry) => {
-      const stats = entry?.attributes;
-      const protectionLevel = stats?.mpaa_protection_level?.data.attributes;
-
+    const parsedProtectionLevel = (protectionLevel, stats) => {
       return {
         title: protectionLevel.name,
         slug: protectionLevel.slug,
         background: PROTECTION_TYPES_CHART_COLORS[protectionLevel.slug],
         totalArea: location.totalMarineArea,
-        protectedArea: stats.area,
+        protectedArea: stats?.area,
         info: protectionLevel.info,
       };
+    };
+
+    const parsedMpaaProtectionLevelData = mpaaProtectionLevelStatsData.map((entry) => {
+      const stats = entry?.attributes;
+      const protectionLevel = stats?.mpaa_protection_level?.data.attributes;
+      return parsedProtectionLevel(protectionLevel, stats);
     });
 
     const parsedFishingProtectionLevelData = fishingProtectionLevelStatsData.map((entry) => {
       const stats = entry?.attributes;
       const protectionLevel = stats?.fishing_protection_level?.data.attributes;
-
-      return {
-        title: protectionLevel.name,
-        slug: protectionLevel.slug,
-        background: PROTECTION_TYPES_CHART_COLORS[protectionLevel.slug],
-        totalArea: location.totalMarineArea,
-        protectedArea: stats.area,
-        info: protectionLevel.info,
-      };
+      return parsedProtectionLevel(protectionLevel, stats);
     });
 
     return [...parsedMpaaProtectionLevelData, ...parsedFishingProtectionLevelData];
-  }, [location, protectionLevelStatsData, fishingProtectionLevelStatsData]);
+  }, [location, mpaaProtectionLevelStatsData, fishingProtectionLevelStatsData]);
 
   const noData = !widgetChartData.length;
+
   const loading =
-    isFetchingProtectionStatsData ||
+    isFetchingMpaaProtectionStatsData ||
     isFetchingFishingProtectionStatsData ||
     isFetchingDataLastUpdate;
 

--- a/frontend/src/containers/map/sidebar/details/widgets/protection-types/index.tsx
+++ b/frontend/src/containers/map/sidebar/details/widgets/protection-types/index.tsx
@@ -59,9 +59,9 @@ const ProtectionTypesWidget: React.FC<ProtectionTypesWidgetProps> = ({ location 
   const widgetChartData = useMemo(() => {
     if (!protectionLevelsData.length) return [];
 
-    const parsedProtectionLevel = (protectionLevel, stats) => {
+    const parsedProtectionLevel = (label, protectionLevel, stats) => {
       return {
-        title: protectionLevel.name,
+        title: label,
         slug: protectionLevel.slug,
         background: PROTECTION_TYPES_CHART_COLORS[protectionLevel.slug],
         totalArea: location.totalMarineArea,
@@ -74,14 +74,14 @@ const ProtectionTypesWidget: React.FC<ProtectionTypesWidgetProps> = ({ location 
       protectionLevelsData[0]?.attributes?.mpaa_protection_level_stats?.data?.map((entry) => {
         const stats = entry?.attributes;
         const protectionLevel = stats?.mpaa_protection_level?.data.attributes;
-        return parsedProtectionLevel(protectionLevel, stats);
+        return parsedProtectionLevel('Fully or highly protected', protectionLevel, stats);
       });
 
     const parsedFishingProtectionLevelData =
       protectionLevelsData[0]?.attributes?.fishing_protection_level_stats?.data?.map((entry) => {
         const stats = entry?.attributes;
         const protectionLevel = stats?.fishing_protection_level?.data.attributes;
-        return parsedProtectionLevel(protectionLevel, stats);
+        return parsedProtectionLevel('Highly protected from fishing', protectionLevel, stats);
       });
 
     return [...parsedMpaaProtectionLevelData, ...parsedFishingProtectionLevelData];


### PR DESCRIPTION
### Overview

This PR adds the "highly protected from fishing" indicator to the "Marine Conservation Protection Levels" widget. 
Data fetching was also simplified into a single query. 

### Feature relevant tickets

[SKY30-226](https://vizzuality.atlassian.net/browse/SKY30-226)