### PR TITLE
[SKY30-218] Ensure consistency across indicators

### DIFF
--- a/frontend/src/containers/homepage/intro/index.tsx
+++ b/frontend/src/containers/homepage/intro/index.tsx
@@ -7,6 +7,7 @@ import SidebarItem from '@/containers/homepage/intro/sidebar-item';
 import { formatPercentage } from '@/lib/utils/formats';
 import ArrowRight from '@/styles/icons/arrow-right.svg?sprite';
 import { useGetProtectionCoverageStats } from '@/types/generated/protection-coverage-stat';
+import { useGetStaticIndicators } from '@/types/generated/static-indicator';
 
 type IntroProps = {
   onScrollClick: () => void;
@@ -31,6 +32,20 @@ const Intro: React.FC<IntroProps> = ({ onScrollClick }) => {
     {
       query: {
         select: ({ data }) => ({ data }),
+        placeholderData: { data: [] },
+      },
+    }
+  );
+
+  const { data: protectedTerrestrialInlandAreasData } = useGetStaticIndicators(
+    {
+      filters: {
+        slug: 'protected-land-area-percentage',
+      },
+    },
+    {
+      query: {
+        select: ({ data }) => data?.[0],
         placeholderData: { data: [] },
       },
     }
@@ -109,7 +124,7 @@ const Intro: React.FC<IntroProps> = ({ onScrollClick }) => {
               icon="icon1"
             />
             <SidebarItem
-              percentage={17.2}
+              percentage={protectedTerrestrialInlandAreasData?.attributes?.value}
               text="Current global land and inland waters protected area"
               icon="icon2"
             />

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -27,6 +27,9 @@ const STATIC_INDICATOR_MAPPING = {
   biodiversity: 'species-threatened-with-extinction',
   climate: 'earth-co2-stored-cycled',
   livesLivelihoods: 'lives-impact',
+  biodiversityTextNumber: 'species-threathened-number',
+  biodiversityTextOcean: 'protected-world-ocean-percentage',
+  biodiversityTextLand: 'protected-land-area-percentage',
 };
 
 export const getServerSideProps: GetServerSideProps = async () => {
@@ -156,30 +159,30 @@ const Home: React.FC = ({
                   Today,{' '}
                   <a
                     className="underline"
-                    href="https://www.protectedplanet.net/en"
+                    href={indicators?.biodiversityTextOcean?.source}
                     target="_blank"
                     rel="noopener noreferrer"
                   >
-                    8.1 percent of the world’s ocean
+                    {indicators?.biodiversityTextOcean?.value} percent of the world’s ocean
                   </a>{' '}
                   and{' '}
                   <a
                     className="underline"
-                    href="https://www.protectedplanet.net/en"
+                    href={indicators?.biodiversityTextLand?.source}
                     target="_blank"
                     rel="noopener noreferrer"
                   >
-                    17.2 percent of its land area
+                    {indicators?.biodiversityTextLand?.value} percent of its land area
                   </a>{' '}
                   are protected . Wildlife populations - mammals, birds, fish, and other species -
                   have decreased by nearly 70% since 1970, with up to{' '}
                   <a
                     className="underline"
-                    href="https://www.iucnredlist.org/"
+                    href={indicators?.biodiversity?.source}
                     target="_blank"
                     rel="noopener noreferrer"
                   >
-                    44,000 species threatened with extinction
+                    {indicators?.biodiversity?.value} species threatened with extinction
                   </a>
                   .
                 </p>

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -153,10 +153,35 @@ const Home: React.FC = ({
             description={
               <>
                 <p>
-                  Today, 8 percent of the world’s ocean and 15 percent of its land area are
-                  protected. Wildlife populations - mammals, birds, fish, and other species - have{' '}
-                  <u>decreased by nearly 70% since 1970</u>, with up to{' '}
-                  <u>1 million species threatened with extinction</u>.
+                  Today,{' '}
+                  <a
+                    className="underline"
+                    href="https://www.protectedplanet.net/en"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    8.1 percent of the world’s ocean
+                  </a>{' '}
+                  and{' '}
+                  <a
+                    className="underline"
+                    href="https://www.protectedplanet.net/en"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    17.2 percent of its land area
+                  </a>{' '}
+                  are protected . Wildlife populations - mammals, birds, fish, and other species -
+                  have decreased by nearly 70% since 1970, with up to{' '}
+                  <a
+                    className="underline"
+                    href="https://www.iucnredlist.org/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    44,000 species threatened with extinction
+                  </a>
+                  .
                 </p>
                 <p className="mt-4 font-bold">
                   Protecting 30 percent of the world’s land and ocean habitats by 2030 will help


### PR DESCRIPTION
### Overview

This PR makes it so that all remaining static indicators displayed in the homepage are pulled from the CMS, including the Intro ones. 

### Feature relevant tickets

[SKY30-218](https://vizzuality.atlassian.net/browse/SKY30-218)

[SKY30-218]: https://vizzuality.atlassian.net/browse/SKY30-218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ