### PR TITLE
[SKY30-244] Remove blue arrow when the details tables are open + styling changes

### DIFF
--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -22,7 +22,7 @@ const buttonVariants = cva(
         // link: 'text-slate-900 underline-offset-4 hover:underline',
         white: 'bg-white border border-black',
         'sidebar-details':
-          'bg-blue text-black text-sm justify-start text-left text-sm hover:brightness-90 font-bold uppercase md:px-8 focus-visible:ring-black',
+          'bg-blue text-black text-sm justify-start text-center text-sm hover:brightness-90 font-bold uppercase md:px-8 focus-visible:ring-black',
         'text-link': 'text-sm font-semibold uppercase underline focus-visible:ring-black',
         blue: 'bg-blue text-black text-sm focus-visible:ring-black hover:brightness-90 font-bold border border-black',
       },

--- a/frontend/src/containers/map/sidebar/details/details-button/index.tsx
+++ b/frontend/src/containers/map/sidebar/details/details-button/index.tsx
@@ -1,11 +1,10 @@
-import { ComponentProps, useCallback } from 'react';
+import { useCallback } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { useSyncMapContentSettings } from '@/containers/map/sync-settings';
-import { cn } from '@/lib/classnames';
 
 const DetailsButton: React.FC = () => {
-  const [{ showDetails }, setSettings] = useSyncMapContentSettings();
+  const [, setSettings] = useSyncMapContentSettings();
 
   const handleButtonClick = useCallback(() => {
     setSettings((prevSettings) => ({ ...prevSettings, showDetails: !prevSettings.showDetails }));
@@ -13,20 +12,12 @@ const DetailsButton: React.FC = () => {
 
   return (
     <Button
-      className={cn('h-12 border-t border-black', {
-        'border-r !px-2': showDetails,
-        'flex justify-between px-5 md:px-8': !showDetails,
-      })}
+      className="flex h-12 justify-between border-t border-black px-5 md:px-8"
       variant="sidebar-details"
-      size={
-        cn({
-          default: showDetails,
-          full: !showDetails,
-        }) as ComponentProps<typeof Button>['size']
-      }
+      size="full"
       onClick={handleButtonClick}
     >
-      {!showDetails && <span className="pt-1 font-mono">Marine Conservation Details</span>}
+      <span className="pt-1 font-mono">Marine Conservation Details</span>
     </Button>
   );
 };

--- a/frontend/src/containers/map/sidebar/details/details-button/index.tsx
+++ b/frontend/src/containers/map/sidebar/details/details-button/index.tsx
@@ -17,7 +17,7 @@ const DetailsButton: React.FC = () => {
       size="full"
       onClick={handleButtonClick}
     >
-      <span className="pt-1 font-mono">Marine Conservation Details</span>
+      <span className="w-full pt-1 font-mono text-xs">Marine Conservation Details</span>
     </Button>
   );
 };

--- a/frontend/src/containers/map/sidebar/details/details-button/index.tsx
+++ b/frontend/src/containers/map/sidebar/details/details-button/index.tsx
@@ -1,7 +1,5 @@
 import { ComponentProps, useCallback } from 'react';
 
-import { ArrowRight } from 'lucide-react';
-
 import { Button } from '@/components/ui/button';
 import { useSyncMapContentSettings } from '@/containers/map/sync-settings';
 import { cn } from '@/lib/classnames';
@@ -29,7 +27,6 @@ const DetailsButton: React.FC = () => {
       onClick={handleButtonClick}
     >
       {!showDetails && <span className="pt-1 font-mono">Marine Conservation Details</span>}
-      <ArrowRight aria-hidden />
     </Button>
   );
 };

--- a/frontend/src/containers/map/sidebar/details/details-button/index.tsx
+++ b/frontend/src/containers/map/sidebar/details/details-button/index.tsx
@@ -12,7 +12,7 @@ const DetailsButton: React.FC = () => {
 
   return (
     <Button
-      className="flex h-12 justify-between border-t border-black px-5 md:px-8"
+      className="flex h-10 justify-between border-t border-black px-5 md:px-8"
       variant="sidebar-details"
       size="full"
       onClick={handleButtonClick}

--- a/frontend/src/containers/map/sidebar/details/index.tsx
+++ b/frontend/src/containers/map/sidebar/details/index.tsx
@@ -37,7 +37,7 @@ const SidebarDetails: React.FC = () => {
         </div>
         <div
           className={cn('absolute bottom-0 left-px ', {
-            'right-px': !showDetails,
+            'right-px': true,
           })}
         >
           <DetailsButton />


### PR DESCRIPTION
### Overview

**In this PR:**  
- When the details tables are open, we no longer display the small back arrow (instead we keep the _"Marine Conservation Details"_ button visible  
- _"Marine Conservation Details"_ styling changes to better match the designs  
  - Centered text  
  - No arrow / chevron  
  - Height to _40px_  
  - Decreased font size  


### Feature relevant tickets

[SKY30-244](https://vizzuality.atlassian.net/browse/SKY30-244)

[SKY30-244]: https://vizzuality.atlassian.net/browse/SKY30-244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ