### PR TITLE
[SKY30-275] Close sidebar button to be the same height as the blue buttons next to it

### DIFF
--- a/frontend/src/containers/map/sidebar/index.tsx
+++ b/frontend/src/containers/map/sidebar/index.tsx
@@ -57,7 +57,7 @@ const MapSidebar: React.FC = () => {
         <Button
           type="button"
           variant="white"
-          className={cn('absolute bottom-0 z-10 h-12 border-l-0 px-1 !py-3', {
+          className={cn('absolute bottom-0 z-10 h-10 border-l-0 px-1 !py-3', {
             'hidden md:flex': true,
             'left-0': !isSidebarOpen,
             'left-[460px] transition-[left] delay-500': isSidebarOpen,


### PR DESCRIPTION
### Overview

This PR adjusts the button that closes the map sidebar to match the height of the blue buttons next to it. 

### Feature relevant tickets
[SKY30-275](https://vizzuality.atlassian.net/browse/SKY30-275)

[SKY30-275]: https://vizzuality.atlassian.net/browse/SKY30-275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ