### PR TITLE
[SKY30-258] Legend items open by default

### DIFF
--- a/frontend/src/components/ui/collapsible.tsx
+++ b/frontend/src/components/ui/collapsible.tsx
@@ -1,9 +1,28 @@
+import * as React from 'react';
+
 import * as CollapsiblePrimitive from '@radix-ui/react-collapsible';
+
+import { cn } from '@/lib/classnames';
 
 const Collapsible = CollapsiblePrimitive.Root;
 
 const CollapsibleTrigger = CollapsiblePrimitive.CollapsibleTrigger;
 
-const CollapsibleContent = CollapsiblePrimitive.CollapsibleContent;
+const CollapsibleContent = React.forwardRef<
+  React.ElementRef<typeof CollapsiblePrimitive.CollapsibleContent>,
+  React.ComponentPropsWithoutRef<typeof CollapsiblePrimitive.CollapsibleContent>
+>(({ className, children, ...props }, ref) => (
+  <CollapsiblePrimitive.CollapsibleContent
+    ref={ref}
+    className={cn(
+      'overflow-y-hidden data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down',
+      className
+    )}
+    {...props}
+  >
+    {children}
+  </CollapsiblePrimitive.CollapsibleContent>
+));
+CollapsibleContent.displayName = CollapsiblePrimitive.Content.displayName;
 
 export { Collapsible, CollapsibleTrigger, CollapsibleContent };

--- a/frontend/src/containers/map/content/map/layers-toolbox/index.tsx
+++ b/frontend/src/containers/map/content/map/layers-toolbox/index.tsx
@@ -7,7 +7,7 @@ import Legend from './legend';
 
 const TABS_TRIGGER_CLASSES =
   'group flex flex-1 items-center space-x-1 rounded-none border border-b-0 border-black py-3 px-6 font-mono text-sm font-bold uppercase leading-none text-black last:border-l-0 data-[state=active]:bg-orange';
-// TODO DEBUG
+
 const LayersToolbox = (): JSX.Element => {
   const [activeLayers] = useSyncMapLayers();
 

--- a/frontend/src/containers/map/content/map/layers-toolbox/index.tsx
+++ b/frontend/src/containers/map/content/map/layers-toolbox/index.tsx
@@ -7,7 +7,7 @@ import Legend from './legend';
 
 const TABS_TRIGGER_CLASSES =
   'group flex flex-1 items-center space-x-1 rounded-none border border-b-0 border-black py-3 px-6 font-mono text-sm font-bold uppercase leading-none text-black last:border-l-0 data-[state=active]:bg-orange';
-
+// TODO DEBUG
 const LayersToolbox = (): JSX.Element => {
   const [activeLayers] = useSyncMapLayers();
 

--- a/frontend/src/containers/map/content/map/layers-toolbox/layers-list/index.tsx
+++ b/frontend/src/containers/map/content/map/layers-toolbox/layers-list/index.tsx
@@ -83,8 +83,10 @@ const LayersDropdown = (): JSX.Element => {
       <Collapsible defaultOpen={Boolean(activeLayers.length)}>
         <CollapsibleTrigger className={COLLAPSIBLE_TRIGGER_CLASSES}>
           <span>Data Layers</span>
-          <LuChevronDown className={`hidden group-data-[state=open]:block ${TABS_ICONS_CLASSES}`} />
-          <LuChevronUp className={`hidden group-data-[state=closed]:block ${TABS_ICONS_CLASSES}`} />
+          <LuChevronDown
+            className={`hidden group-data-[state=closed]:block ${TABS_ICONS_CLASSES}`}
+          />
+          <LuChevronUp className={`hidden group-data-[state=open]:block ${TABS_ICONS_CLASSES}`} />
         </CollapsibleTrigger>
         <CollapsibleContent className="border-b border-dashed border-black/20">
           <ul className="my-3 flex flex-col space-y-5">
@@ -121,8 +123,10 @@ const LayersDropdown = (): JSX.Element => {
           className={`${COLLAPSIBLE_TRIGGER_CLASSES} pb-0 data-[state=open]:pb-2`}
         >
           <span>basemap Layers</span>
-          <LuChevronDown className={`hidden group-data-[state=open]:block ${TABS_ICONS_CLASSES}`} />
-          <LuChevronUp className={`hidden group-data-[state=closed]:block ${TABS_ICONS_CLASSES}`} />
+          <LuChevronDown
+            className={`hidden group-data-[state=closed]:block ${TABS_ICONS_CLASSES}`}
+          />
+          <LuChevronUp className={`hidden group-data-[state=open]:block ${TABS_ICONS_CLASSES}`} />
         </CollapsibleTrigger>
         <CollapsibleContent>
           <ul className="my-3 flex flex-col space-y-5 overflow-y-hidden">

--- a/frontend/src/containers/map/content/map/layers-toolbox/layers-list/index.tsx
+++ b/frontend/src/containers/map/content/map/layers-toolbox/layers-list/index.tsx
@@ -125,7 +125,7 @@ const LayersDropdown = (): JSX.Element => {
           <LuChevronUp className={`hidden group-data-[state=closed]:block ${TABS_ICONS_CLASSES}`} />
         </CollapsibleTrigger>
         <CollapsibleContent>
-          <ul className="my-3 flex flex-col space-y-5">
+          <ul className="my-3 flex flex-col space-y-5 overflow-y-hidden">
             <li className="flex items-start gap-2">
               <Switch id="labels-switch" checked={labels} onCheckedChange={handleLabelsChange} />
               <Label htmlFor="labels-switch" className="cursor-pointer">

--- a/frontend/src/containers/map/content/map/layers-toolbox/layers-list/index.tsx
+++ b/frontend/src/containers/map/content/map/layers-toolbox/layers-list/index.tsx
@@ -20,7 +20,7 @@ const TABS_ICONS_CLASSES = 'w-5 h-5 -translate-y-[2px]';
 
 const LayersDropdown = (): JSX.Element => {
   const [activeLayers, setMapLayers] = useSyncMapLayers();
-  const [, setLayerSettings] = useSyncMapLayerSettings();
+  const [layerSettings, setLayerSettings] = useSyncMapLayerSettings();
   const [{ labels }, setMapSettings] = useSyncMapSettings();
 
   const layersQuery = useGetLayers(
@@ -45,7 +45,19 @@ const LayersDropdown = (): JSX.Element => {
           : activeLayers.filter((_layerId) => _layerId !== Number(layerId))
       );
 
+      // If we don't have layerSettings entries, the view is in its default state; we wish to
+      // show all legend accordion items expanded by default.
+      const initialSettings = (() => {
+        const layerSettingsKeys = Object.keys(layerSettings);
+        if (layerSettingsKeys.length) return {};
+        return Object.assign(
+          {},
+          ...activeLayers.map((layerId) => ({ [layerId]: { expanded: true } }))
+        );
+      })();
+
       setLayerSettings((prev) => ({
+        ...initialSettings,
         ...prev,
         [layerId]: {
           ...prev[layerId],
@@ -53,7 +65,7 @@ const LayersDropdown = (): JSX.Element => {
         },
       }));
     },
-    [activeLayers, setLayerSettings, setMapLayers]
+    [activeLayers, layerSettings, setLayerSettings, setMapLayers]
   );
 
   const handleLabelsChange = useCallback(

--- a/frontend/src/containers/map/content/map/layers-toolbox/legend/index.tsx
+++ b/frontend/src/containers/map/content/map/layers-toolbox/legend/index.tsx
@@ -179,7 +179,7 @@ const Legend: FC = () => {
                   <TooltipProvider>
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <AccordionTrigger className="overflow-hidden text-ellipsis whitespace-nowrap text-xs font-bold ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black focus-visible:ring-offset-2 [&_svg]:aria-[expanded=true]:rotate-180">
+                        <AccordionTrigger className="overflow-hidden text-ellipsis whitespace-nowrap text-xs font-bold ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black focus-visible:ring-offset-2 [&_svg]:aria-[expanded=false]:rotate-180">
                           <ChevronDown className="mr-2 inline-block h-4 w-4" aria-hidden />
                           {title}
                         </AccordionTrigger>

--- a/frontend/src/containers/map/content/map/layers-toolbox/legend/index.tsx
+++ b/frontend/src/containers/map/content/map/layers-toolbox/legend/index.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback } from 'react';
+import { FC, useCallback, useMemo } from 'react';
 
 import { ChevronDown } from 'lucide-react';
 import { HiEye, HiEyeOff } from 'react-icons/hi';
@@ -136,6 +136,20 @@ const Legend: FC = () => {
     [activeLayers, setLayerSettings]
   );
 
+  const accordionValue = useMemo(() => {
+    // If we don't have layerSettings entries, the view is in its default state; we wish to
+    // show all legend accordion items expanded by default.
+    const layerSettingsKeys = Object.keys(layerSettings);
+    if (!layerSettingsKeys.length) {
+      return activeLayers.map((layerId) => layerId.toString());
+    }
+
+    // We have layerSettings entries; let's use those to define which accordion items are expanded.
+    return layerSettingsKeys.filter((layerId) =>
+      layerSettings[layerId].expanded ? layerId.toString() : null
+    );
+  }, [activeLayers, layerSettings]);
+
   return (
     <>
       {!layersQuery.data?.length && (
@@ -144,13 +158,7 @@ const Legend: FC = () => {
         </p>
       )}
       {layersQuery.data?.length > 0 && (
-        <Accordion
-          type="multiple"
-          value={Object.keys(layerSettings).filter((layerId) => {
-            return layerSettings[layerId].expanded ? layerId.toString() : null;
-          })}
-          onValueChange={onToggleAccordion}
-        >
+        <Accordion type="multiple" value={accordionValue} onValueChange={onToggleAccordion}>
           {layersQuery.data?.map(({ id, attributes: { title, legend_config } }, index) => {
             const isFirst = index === 0;
             const isLast = index + 1 === layersQuery.data.length;

--- a/frontend/src/containers/map/content/map/layers-toolbox/legend/index.tsx
+++ b/frontend/src/containers/map/content/map/layers-toolbox/legend/index.tsx
@@ -179,7 +179,7 @@ const Legend: FC = () => {
                   <TooltipProvider>
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <AccordionTrigger className="overflow-hidden text-ellipsis whitespace-nowrap text-xs font-bold ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black focus-visible:ring-offset-2 [&_svg]:aria-[expanded=false]:rotate-180">
+                        <AccordionTrigger className="overflow-hidden text-ellipsis whitespace-nowrap text-xs font-bold ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black focus-visible:ring-offset-2 [&_svg]:aria-[expanded=true]:rotate-180">
                           <ChevronDown className="mr-2 inline-block h-4 w-4" aria-hidden />
                           {title}
                         </AccordionTrigger>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -45,10 +45,20 @@ module.exports = {
           from: { height: 'var(--radix-accordion-content-height)' },
           to: { height: 0 },
         },
+        'collapsible-down': {
+          from: { height: 0 },
+          to: { height: 'var(--radix-collapsible-content-height)' },
+        },
+        'collapsible-up': {
+          from: { height: 'var(--radix-collapsible-content-height)' },
+          to: { height: 0 },
+        },
       },
       animation: {
         'accordion-down': 'accordion-down 0.2s ease-out',
         'accordion-up': 'accordion-up 0.2s ease-out',
+        'collapsible-down': 'collapsible-down 0.2s ease-out',
+        'collapsible-up': 'collapsible-up 0.2s ease-out',
       },
     },
   },


### PR DESCRIPTION
### Overview

This PR makes it so that the legend items are open by default. 

**In this PR:**  
- Legend items are open by default  
  - Because which items are open is tied to the sync settings, and in order to prevent applying sync settings on load for performance and maintainability reasons, the code first checks whether we have settings. If not all items are open by default. If yes, it's not a first load, so sync settings are respected  
  - Same logic as above is implemented for when the user toggles a layer on  
  - Added an animation to the Collapsible component
    - So that both legend and layers tabs have similar animations
  - Dropdown/Accordion arrows now display similar behaviours as well 

### Feature relevant tickets

[SKY30-258](https://vizzuality.atlassian.net/browse/SKY30-258)

[SKY30-258]: https://vizzuality.atlassian.net/browse/SKY30-258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ