### PR TITLE
[SKY30-278] Regions table area to calculate global contribution based on the global area

### DIFF
--- a/frontend/src/containers/map/content/details/tables/global-regional/index.tsx
+++ b/frontend/src/containers/map/content/details/tables/global-regional/index.tsx
@@ -12,6 +12,19 @@ const GlobalRegionalTable: React.FC = () => {
     query: { locationCode },
   } = useRouter();
 
+  const globalLocationQuery = useGetLocations(
+    {
+      filters: {
+        code: 'GLOB',
+      },
+    },
+    {
+      query: {
+        select: ({ data }) => data?.[0]?.attributes,
+      },
+    }
+  );
+
   const locationsQuery = useGetLocations(
     {
       filters: {
@@ -150,7 +163,7 @@ const GlobalRegionalTable: React.FC = () => {
 
       // Global contributions calculations
       const globalContributionPercentage =
-        (protectedArea * 100) / locationsQuery.data?.totalMarineArea;
+        (protectedArea * 100) / globalLocationQuery?.data?.totalMarineArea;
 
       return {
         location: location.name,
@@ -165,7 +178,7 @@ const GlobalRegionalTable: React.FC = () => {
         globalContribution: globalContributionPercentage,
       };
     });
-  }, [locationsQuery.data, locationsData]);
+  }, [globalLocationQuery?.data, locationsData]);
 
   const tableData = parsedData;
 


### PR DESCRIPTION
### Overview

The regions table is incorrectly calculating the percentage of the global contribution based on the selected region area, instead of the global one. This PR fixes that calculation. 

### Feature relevant tickets

[SKY30-278](https://vizzuality.atlassian.net/browse/SKY30-278)