### PR TITLE
[SKY30-279] Global/regional tables to display the protected area and not the total area in the area column

### DIFF
--- a/frontend/src/containers/map/content/details/tables/global-regional/index.tsx
+++ b/frontend/src/containers/map/content/details/tables/global-regional/index.tsx
@@ -12,6 +12,19 @@ const GlobalRegionalTable: React.FC = () => {
     query: { locationCode },
   } = useRouter();
 
+  const globalLocationQuery = useGetLocations(
+    {
+      filters: {
+        code: 'GLOB',
+      },
+    },
+    {
+      query: {
+        select: ({ data }) => data?.[0]?.attributes,
+      },
+    }
+  );
+
   const locationsQuery = useGetLocations(
     {
       filters: {
@@ -150,7 +163,7 @@ const GlobalRegionalTable: React.FC = () => {
 
       // Global contributions calculations
       const globalContributionPercentage =
-        (protectedArea * 100) / locationsQuery.data?.totalMarineArea;
+        (protectedArea * 100) / globalLocationQuery?.data?.totalMarineArea;
 
       return {
         location: location.name,
@@ -165,7 +178,7 @@ const GlobalRegionalTable: React.FC = () => {
         globalContribution: globalContributionPercentage,
       };
     });
-  }, [locationsQuery.data, locationsData]);
+  }, [globalLocationQuery?.data, locationsData]);
 
   const tableData = parsedData;
 

--- a/frontend/src/containers/map/content/details/tables/global-regional/index.tsx
+++ b/frontend/src/containers/map/content/details/tables/global-regional/index.tsx
@@ -168,6 +168,7 @@ const GlobalRegionalTable: React.FC = () => {
       return {
         location: location.name,
         locationCode: location.code,
+        totalMarineArea: location.totalMarineArea,
         coverage: coveragePercentage,
         area: protectedArea,
         locationType: location.type,

--- a/frontend/src/containers/map/content/details/tables/global-regional/index.tsx
+++ b/frontend/src/containers/map/content/details/tables/global-regional/index.tsx
@@ -169,7 +169,7 @@ const GlobalRegionalTable: React.FC = () => {
         location: location.name,
         locationCode: location.code,
         coverage: coveragePercentage,
-        area: location.totalMarineArea,
+        area: protectedArea,
         locationType: location.type,
         mpas: percentageMPAs,
         oecms: percentageOECMs,

--- a/frontend/src/containers/map/content/details/tables/global-regional/useColumns.tsx
+++ b/frontend/src/containers/map/content/details/tables/global-regional/useColumns.tsx
@@ -15,6 +15,7 @@ import { useMapSearchParams } from '@/containers/map/content/map/sync-settings';
 export type GlobalRegionalTableColumns = {
   location: string;
   locationCode: string;
+  totalMarineArea: number;
   coverage: number;
   locationType: string;
   mpas: number;
@@ -85,11 +86,20 @@ const useColumns = () => {
           </HeaderItem>
         ),
         cell: ({ row }) => {
-          const { area: value } = row.original;
+          const { totalMarineArea, area: value } = row.original;
           const formattedValue = cellFormatter.area(value);
+          let displayValue = formattedValue;
+
+          // In certain circumstances, due to rounding, the formatted value may exceed the
+          // total marine area, mostly in situations where the coverage is nearing 100%.
+          // In this case, we skip the rounding and display the value.
+          if (parseFloat(formattedValue) > totalMarineArea) {
+            displayValue = value.toString();
+          }
+
           return (
             <span>
-              {formattedValue} km<sup>2</sup>
+              {displayValue} km<sup>2</sup>
             </span>
           );
         },


### PR DESCRIPTION
### Overview

This PR makes it so that the global/regional tables display the protected area and not the total area (in the area column). 
It also adds a check to ensure that, due to rounding, the protected area does not exceed the total marine area (which can happen when coverage is near 100%). 

### Note  

This PR includes commits from #197 , which should be merged first. 
This was to prevent code conflicts. 

### Feature relevant tickets

[SKY30-279](https://vizzuality.atlassian.net/browse/SKY30-279)

[SKY30-279]: https://vizzuality.atlassian.net/browse/SKY30-279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ