### PR TITLE
[SKY30-280] Area in protection types widget should be total area within the classification

### DIFF
--- a/frontend/src/components/charts/horizontal-bar-chart/index.tsx
+++ b/frontend/src/components/charts/horizontal-bar-chart/index.tsx
@@ -20,6 +20,7 @@ type HorizontalBarChartProps = {
   };
   showLegend?: boolean;
   showTarget?: boolean;
+  areaToDisplay?: 'total-area' | 'protected-area';
 };
 
 const HorizontalBarChart: React.FC<HorizontalBarChartProps> = ({
@@ -27,6 +28,7 @@ const HorizontalBarChart: React.FC<HorizontalBarChartProps> = ({
   data,
   showLegend = true,
   showTarget = true,
+  areaToDisplay = 'total-area',
 }) => {
   const { title, background, totalArea, protectedArea, info } = data;
 
@@ -47,8 +49,9 @@ const HorizontalBarChart: React.FC<HorizontalBarChartProps> = ({
   }, [protectedArea, totalArea]);
 
   const formattedArea = useMemo(() => {
-    return format(',.0f')(totalArea);
-  }, [totalArea]);
+    const area = areaToDisplay === 'total-area' ? totalArea : protectedArea;
+    return format(',.0f')(area);
+  }, [areaToDisplay, protectedArea, totalArea]);
 
   return (
     <div className={cn('font-mono', className)}>
@@ -62,7 +65,7 @@ const HorizontalBarChart: React.FC<HorizontalBarChartProps> = ({
           {info && <TooltipButton text={info} />}
         </span>
         <span>
-          of {formattedArea} km<sup>2</sup>
+          {areaToDisplay === 'total-area' && 'of'} {formattedArea} km<sup>2</sup>
         </span>
       </div>
       <div className="relative my-2 flex h-3.5">

--- a/frontend/src/components/charts/horizontal-bar-chart/index.tsx
+++ b/frontend/src/components/charts/horizontal-bar-chart/index.tsx
@@ -15,12 +15,13 @@ type HorizontalBarChartProps = {
     background: string;
     title?: string;
     totalArea: number;
+    indicatorArea: number;
     protectedArea: number;
     info?: string;
   };
   showLegend?: boolean;
   showTarget?: boolean;
-  areaToDisplay?: 'total-area' | 'protected-area';
+  areaToDisplay?: 'total-area' | 'indicator-area' | 'protected-area';
 };
 
 const HorizontalBarChart: React.FC<HorizontalBarChartProps> = ({
@@ -30,7 +31,7 @@ const HorizontalBarChart: React.FC<HorizontalBarChartProps> = ({
   showTarget = true,
   areaToDisplay = 'total-area',
 }) => {
-  const { title, background, totalArea, protectedArea, info } = data;
+  const { title, background, totalArea, indicatorArea, protectedArea, info } = data;
 
   const targetPositionPercentage = useMemo(() => {
     return (PROTECTION_TARGET * 100) / DEFAULT_MAX_PERCENTAGE;
@@ -49,9 +50,14 @@ const HorizontalBarChart: React.FC<HorizontalBarChartProps> = ({
   }, [protectedArea, totalArea]);
 
   const formattedArea = useMemo(() => {
-    const area = areaToDisplay === 'total-area' ? totalArea : protectedArea;
+    const area =
+      areaToDisplay === 'total-area'
+        ? totalArea
+        : areaToDisplay === 'indicator-area'
+        ? indicatorArea
+        : protectedArea;
     return format(',.0f')(area);
-  }, [areaToDisplay, protectedArea, totalArea]);
+  }, [areaToDisplay, indicatorArea, protectedArea, totalArea]);
 
   return (
     <div className={cn('font-mono', className)}>
@@ -65,7 +71,7 @@ const HorizontalBarChart: React.FC<HorizontalBarChartProps> = ({
           {info && <TooltipButton text={info} />}
         </span>
         <span>
-          {areaToDisplay === 'total-area' && 'of'} {formattedArea} km<sup>2</sup>
+          {areaToDisplay === 'total-area' || areaToDisplay === 'indicator-area' && 'of'} {formattedArea} km<sup>2</sup>
         </span>
       </div>
       <div className="relative my-2 flex h-3.5">

--- a/frontend/src/components/charts/horizontal-bar-chart/index.tsx
+++ b/frontend/src/components/charts/horizontal-bar-chart/index.tsx
@@ -15,7 +15,7 @@ type HorizontalBarChartProps = {
     background: string;
     title?: string;
     totalArea: number;
-    indicatorArea: number;
+    indicatorArea?: number;
     protectedArea: number;
     info?: string;
   };
@@ -71,7 +71,8 @@ const HorizontalBarChart: React.FC<HorizontalBarChartProps> = ({
           {info && <TooltipButton text={info} />}
         </span>
         <span>
-          {areaToDisplay === 'total-area' || areaToDisplay === 'indicator-area' && 'of'} {formattedArea} km<sup>2</sup>
+          {areaToDisplay === 'total-area' || (areaToDisplay === 'indicator-area' && 'of')}{' '}
+          {formattedArea} km<sup>2</sup>
         </span>
       </div>
       <div className="relative my-2 flex h-3.5">

--- a/frontend/src/containers/map/sidebar/details/widgets/establishment-stages/index.tsx
+++ b/frontend/src/containers/map/sidebar/details/widgets/establishment-stages/index.tsx
@@ -118,7 +118,12 @@ const EstablishmentStagesWidget: React.FC<EstablishmentStagesWidgetProps> = ({ l
       loading={loading}
     >
       {widgetChartData.map((chartData) => (
-        <HorizontalBarChart key={chartData.slug} className="py-2" data={chartData} areaToDisplay='protected-area' />
+        <HorizontalBarChart
+          key={chartData.slug}
+          className="py-2"
+          data={chartData}
+          areaToDisplay="protected-area"
+        />
       ))}
     </Widget>
   );

--- a/frontend/src/containers/map/sidebar/details/widgets/establishment-stages/index.tsx
+++ b/frontend/src/containers/map/sidebar/details/widgets/establishment-stages/index.tsx
@@ -118,7 +118,7 @@ const EstablishmentStagesWidget: React.FC<EstablishmentStagesWidgetProps> = ({ l
       loading={loading}
     >
       {widgetChartData.map((chartData) => (
-        <HorizontalBarChart key={chartData.slug} className="py-2" data={chartData} />
+        <HorizontalBarChart key={chartData.slug} className="py-2" data={chartData} areaToDisplay='protected-area' />
       ))}
     </Widget>
   );

--- a/frontend/src/containers/map/sidebar/details/widgets/protection-types/index.tsx
+++ b/frontend/src/containers/map/sidebar/details/widgets/protection-types/index.tsx
@@ -49,7 +49,10 @@ const ProtectionTypesWidget: React.FC<ProtectionTypesWidgetProps> = ({ location 
   const widgetChartData = useMemo(() => {
     if (!protectionLevelsData.length) return [];
 
-    const parsedProtectionLevel = (label, property, data) => {
+    const parsedProtectionLevel = (label, property, filter, protectionData) => {
+      const data = protectionData[0]?.attributes?.[property + '_stats']?.data?.filter(
+        (entry) => entry?.attributes?.[property]?.data?.attributes?.slug === filter
+      );
       const attributes = data[0]?.attributes;
       const propertyData = attributes[property].data?.attributes;
 
@@ -66,20 +69,18 @@ const ProtectionTypesWidget: React.FC<ProtectionTypesWidgetProps> = ({ location 
     const parsedMpaaProtectionLevelData = parsedProtectionLevel(
       'Fully or highly protected',
       'mpaa_protection_level',
-      protectionLevelsData[0]?.attributes?.mpaa_protection_level_stats?.data?.filter(
-        (entry) =>
-          entry?.attributes?.mpaa_protection_level?.data?.attributes?.slug ===
-          'fully-highly-protected'
-      )
+      'fully-highly-protected',
+      protectionLevelsData
     );
 
     const parsedHighlyProtectedFromFishingData = parsedProtectionLevel(
       'Highly protected from fishing',
       'fishing_protection_level',
-      protectionLevelsData[0]?.attributes?.fishing_protection_level_stats?.data?.filter(
-        (entry) => entry?.attributes?.fishing_protection_level?.data?.attributes?.slug === 'highly'
-      )
+      'highly',
+      protectionLevelsData
     );
+
+    // Debug
     return [parsedMpaaProtectionLevelData, parsedHighlyProtectedFromFishingData];
   }, [location, protectionLevelsData]);
 

--- a/frontend/src/containers/map/sidebar/details/widgets/protection-types/index.tsx
+++ b/frontend/src/containers/map/sidebar/details/widgets/protection-types/index.tsx
@@ -50,9 +50,18 @@ const ProtectionTypesWidget: React.FC<ProtectionTypesWidgetProps> = ({ location 
     if (!protectionLevelsData.length) return [];
 
     const parsedProtectionLevel = (label, property, filter, protectionData) => {
-      const data = protectionData[0]?.attributes?.[property + '_stats']?.data?.filter(
+      const protectionDataAttributes = protectionData?.[0]?.attributes;
+      const protectionDataStatsEntries = protectionDataAttributes?.[property + '_stats']?.data;
+
+      const cumulativeIndicatorProtectedArea = protectionDataStatsEntries.reduce(
+        (protectedArea, { attributes }) => protectedArea + attributes?.area,
+        0
+      );
+
+      const data = protectionDataStatsEntries.filter(
         (entry) => entry?.attributes?.[property]?.data?.attributes?.slug === filter
       );
+
       const attributes = data[0]?.attributes;
       const propertyData = attributes[property].data?.attributes;
 
@@ -61,6 +70,7 @@ const ProtectionTypesWidget: React.FC<ProtectionTypesWidgetProps> = ({ location 
         slug: propertyData?.slug,
         background: PROTECTION_TYPES_CHART_COLORS[propertyData?.slug],
         totalArea: location.totalMarineArea,
+        indicatorArea: cumulativeIndicatorProtectedArea,
         protectedArea: attributes.area,
         info: propertyData?.info,
       };
@@ -80,9 +90,8 @@ const ProtectionTypesWidget: React.FC<ProtectionTypesWidgetProps> = ({ location 
       protectionLevelsData
     );
 
-    // Debug
     return [parsedMpaaProtectionLevelData, parsedHighlyProtectedFromFishingData];
-  }, [location, protectionLevelsData]);
+  }, [location.totalMarineArea, protectionLevelsData]);
 
   const noData = !widgetChartData.length;
   const loading = isFetchingProtectionLevelsData;

--- a/frontend/src/containers/map/sidebar/details/widgets/protection-types/index.tsx
+++ b/frontend/src/containers/map/sidebar/details/widgets/protection-types/index.tsx
@@ -99,7 +99,12 @@ const ProtectionTypesWidget: React.FC<ProtectionTypesWidgetProps> = ({ location 
       loading={loading}
     >
       {widgetChartData.map((chartData) => (
-        <HorizontalBarChart key={chartData.slug} className="py-2" data={chartData} />
+        <HorizontalBarChart
+          key={chartData.slug}
+          className="py-2"
+          data={chartData}
+          areaToDisplay="protected-area"
+        />
       ))}
     </Widget>
   );

--- a/frontend/src/containers/map/sidebar/details/widgets/protection-types/index.tsx
+++ b/frontend/src/containers/map/sidebar/details/widgets/protection-types/index.tsx
@@ -108,7 +108,7 @@ const ProtectionTypesWidget: React.FC<ProtectionTypesWidgetProps> = ({ location 
           key={chartData.slug}
           className="py-2"
           data={chartData}
-          areaToDisplay="protected-area"
+          areaToDisplay="indicator-area"
         />
       ))}
     </Widget>


### PR DESCRIPTION
### Overview

Area in protection types widget should be total area within the classification. 
Right now it displays the total marine area. 

### Feature relevant tickets

[SKY30-280](https://vizzuality.atlassian.net/browse/SKY30-280)

[SKY30-280]: https://vizzuality.atlassian.net/browse/SKY30-280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ