### PR TITLE
[SKY30-256] Add tooltips of the yearly data for the column chart in dashboards

### DIFF
--- a/frontend/src/components/charts/conservation-chart/index.tsx
+++ b/frontend/src/components/charts/conservation-chart/index.tsx
@@ -8,7 +8,7 @@ import {
   CartesianGrid,
   ResponsiveContainer,
   Cell,
-  // Tooltip,
+  Tooltip,
   ReferenceLine,
   Line,
 } from 'recharts';
@@ -205,6 +205,7 @@ const ConservationChart: React.FC<ConservationChartProps> = ({ className, data }
               />
             ))}
           </Bar>
+          <Tooltip />
         </ComposedChart>
       </ResponsiveContainer>
       <ChartLegend />

--- a/frontend/src/components/charts/conservation-chart/index.tsx
+++ b/frontend/src/components/charts/conservation-chart/index.tsx
@@ -18,7 +18,7 @@ import { cn } from '@/lib/classnames';
 import { useGetDataInfos } from '@/types/generated/data-info';
 
 import ChartLegend from './legend';
-// import ChartTooltip from './tooltip';
+import ChartTooltip from './tooltip';
 
 type ConservationChartProps = {
   className?: string;
@@ -249,8 +249,7 @@ const ConservationChart: React.FC<ConservationChartProps> = ({ className, data }
               />
             ))}
           </Bar>
-          {/* <Tooltip content={ChartTooltip} /> */}
-          <Tooltip />
+          <Tooltip content={ChartTooltip} />
         </ComposedChart>
       </ResponsiveContainer>
       <ChartLegend />

--- a/frontend/src/components/charts/conservation-chart/index.tsx
+++ b/frontend/src/components/charts/conservation-chart/index.tsx
@@ -155,7 +155,7 @@ const ConservationChart: React.FC<ConservationChartProps> = ({ className, data }
                   >
                     <TooltipButton
                       text={dataInfo?.attributes.content}
-                      className="hover:bg-transparent"
+                      className="mt-1 hover:bg-transparent"
                     />
                   </foreignObject>
                 </g>

--- a/frontend/src/components/charts/conservation-chart/tooltip/index.tsx
+++ b/frontend/src/components/charts/conservation-chart/tooltip/index.tsx
@@ -1,35 +1,44 @@
-import React, { useMemo } from 'react';
+import React /*, { useMemo }*/ from 'react';
 
-import { format } from 'd3-format';
+// import { format } from 'd3-format';
 
 const ChartTooltip = ({ active, payload }) => {
-  const { percentage, year, protectedArea, totalArea, future } = payload[0]?.payload || {};
+  if (!active || !payload?.[2]) return null;
 
-  const formattedAreas = useMemo(() => {
-    return {
-      protected: format(',.2r')(protectedArea),
-      total: format(',.2r')(totalArea),
-    };
-  }, [protectedArea, totalArea]);
-
-  if (!active || !payload?.length) return null;
+  // console.log({ active, payload });
 
   return (
-    <div className="flex flex-col gap-px rounded-md border border-black bg-white p-4 text-sm">
-      <span>Year: {year}</span>
-      {!future && (
-        <>
-          <span>Protection percentage: {percentage}%</span>
-          <span>
-            Protected area: {formattedAreas.protected} km<sup>2</sup>
-          </span>
-          <span>
-            Total area: {formattedAreas.total} km<sup>2</sup>
-          </span>
-        </>
-      )}
+    <div className="flex flex-col gap-px border border-black bg-white p-4 font-mono text-xs">
+      Coverage: {payload?.[2]?.value}%
     </div>
   );
+  // const { percentage, year, protectedArea, totalArea, future } = payload?.[0]?.payload || {};
+
+  // const formattedAreas = useMemo(() => {
+  //   return {
+  //     protected: format(',.2r')(protectedArea),
+  //     total: format(',.2r')(totalArea),
+  //   };
+  // }, [protectedArea, totalArea]);
+
+  // if (!active || !payload?.length) return null;
+
+  // return (
+  //   <div className="flex flex-col gap-px rounded-md border border-black bg-white p-4 text-sm">
+  //     <span>Year: {year}</span>
+  //     {!future && (
+  //       <>
+  //         <span>Protection percentage: {percentage}%</span>
+  //         <span>
+  //           Protected area: {formattedAreas.protected} km<sup>2</sup>
+  //         </span>
+  //         <span>
+  //           Total area: {formattedAreas.total} km<sup>2</sup>
+  //         </span>
+  //       </>
+  //     )}
+  //   </div>
+  // );
 };
 
 export default ChartTooltip;

--- a/frontend/src/components/charts/conservation-chart/tooltip/index.tsx
+++ b/frontend/src/components/charts/conservation-chart/tooltip/index.tsx
@@ -1,44 +1,21 @@
-import React /*, { useMemo }*/ from 'react';
+import React from 'react';
 
-// import { format } from 'd3-format';
+import { formatPercentage } from '@/lib/utils/formats';
 
 const ChartTooltip = ({ active, payload }) => {
-  if (!active || !payload?.[2]) return null;
+  if (!active || !payload) return null;
 
-  // console.log({ active, payload });
+  const percentageData = payload?.find(({ dataKey }) => dataKey === 'percentage');
+  if (!percentageData?.payload) return null;
+
+  const { percentage, year } = percentageData?.payload;
 
   return (
     <div className="flex flex-col gap-px border border-black bg-white p-4 font-mono text-xs">
-      Coverage: {payload?.[2]?.value}%
+      <span>Year: {year}</span>
+      <span>Coverage: {formatPercentage(percentage)}</span>
     </div>
   );
-  // const { percentage, year, protectedArea, totalArea, future } = payload?.[0]?.payload || {};
-
-  // const formattedAreas = useMemo(() => {
-  //   return {
-  //     protected: format(',.2r')(protectedArea),
-  //     total: format(',.2r')(totalArea),
-  //   };
-  // }, [protectedArea, totalArea]);
-
-  // if (!active || !payload?.length) return null;
-
-  // return (
-  //   <div className="flex flex-col gap-px rounded-md border border-black bg-white p-4 text-sm">
-  //     <span>Year: {year}</span>
-  //     {!future && (
-  //       <>
-  //         <span>Protection percentage: {percentage}%</span>
-  //         <span>
-  //           Protected area: {formattedAreas.protected} km<sup>2</sup>
-  //         </span>
-  //         <span>
-  //           Total area: {formattedAreas.total} km<sup>2</sup>
-  //         </span>
-  //       </>
-  //     )}
-  //   </div>
-  // );
 };
 
 export default ChartTooltip;

--- a/frontend/src/containers/map/sidebar/details/widgets/marine-conservation/index.tsx
+++ b/frontend/src/containers/map/sidebar/details/widgets/marine-conservation/index.tsx
@@ -97,11 +97,10 @@ const MarineConservationWidget: React.FC<MarineConservationWidgetProps> = ({ loc
   const chartData = useMemo(() => {
     if (!mergedProtectionStats?.length) return [];
 
-    const totalArea = location.totalMarineArea;
-    const parsedData = mergedProtectionStats.map((entry, index) => {
+    const data = mergedProtectionStats.map((entry, index) => {
       const isLastYear = index === mergedProtectionStats.length - 1;
       const { year, protectedArea } = entry;
-      const percentage = Math.round((protectedArea * 100) / totalArea);
+      const percentage = Math.round((protectedArea * 100) / location.totalMarineArea);
 
       return {
         // We only want to show up to 55%, so we'll cap the percentage here
@@ -109,32 +108,13 @@ const MarineConservationWidget: React.FC<MarineConservationWidgetProps> = ({ loc
         percentage: percentage > 55 ? 55 : percentage,
         year,
         active: isLastYear,
-        totalArea: totalArea,
+        totalArea: location.totalMarineArea,
         protectedArea,
         future: false,
       };
     });
 
-    const lastEntryYear = parsedData[parsedData.length - 1]?.year;
-    const missingYearsArr = [...Array(2030 - lastEntryYear).keys()].map(
-      (i) => i + lastEntryYear + 1
-    );
-
-    const missingYearsData = missingYearsArr.map((year) => {
-      return {
-        percentage: 0,
-        year: year,
-        active: false,
-        totalArea: null,
-        protectedArea: null,
-        future: true,
-      };
-    });
-
-    const mergedData = [...parsedData, ...missingYearsData];
-
-    // Cap results to the least 20 entries, or chart will be too big
-    return mergedData.slice(-20);
+    return data;
   }, [location, mergedProtectionStats]);
 
   const noData = !chartData.length;

--- a/frontend/src/containers/map/sidebar/details/widgets/marine-conservation/index.tsx
+++ b/frontend/src/containers/map/sidebar/details/widgets/marine-conservation/index.tsx
@@ -100,7 +100,7 @@ const MarineConservationWidget: React.FC<MarineConservationWidgetProps> = ({ loc
     const data = mergedProtectionStats.map((entry, index) => {
       const isLastYear = index === mergedProtectionStats.length - 1;
       const { year, protectedArea } = entry;
-      const percentage = Math.round((protectedArea * 100) / location.totalMarineArea);
+      const percentage = (protectedArea * 100) / location.totalMarineArea;
 
       return {
         // We only want to show up to 55%, so we'll cap the percentage here

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -9,8 +9,8 @@ import { QueryClient, QueryClientProvider, Hydrate } from '@tanstack/react-query
 import 'styles/globals.css';
 import 'mapbox-gl/dist/mapbox-gl.css';
 
-import { figtree, overpassMono } from '@/styles/fonts';
 import Analytics from '@/components/analytics';
+import { figtree, overpassMono } from '@/styles/fonts';
 
 type PageProps = {
   dehydratedState: unknown;


### PR DESCRIPTION
### Overview

**In this PR:**  
- Calculations re-done to the conservation chart  
- Aligned the 30x30 target tooltip button for the coverage chart  
- Enabled tooltips to the yearly columns (bars only)

### Feature relevant tickets

[SKY30-256](https://vizzuality.atlassian.net/browse/SKY30-256)

[SKY30-256]: https://vizzuality.atlassian.net/browse/SKY30-256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ