### PR TITLE
[SKY30-298] Standardize area format across the platform

### DIFF
--- a/frontend/src/containers/map/content/details/table/helpers.ts
+++ b/frontend/src/containers/map/content/details/table/helpers.ts
@@ -1,13 +1,11 @@
-import { format } from 'd3-format';
-
-import { formatPercentage } from '@/lib/utils/formats';
+import { formatPercentage, formatKM } from '@/lib/utils/formats';
 
 const percentage = (value: number) => {
   return formatPercentage(value, { displayPercentageSign: false });
 };
 
 const area = (value: number) => {
-  return format(',.2r')(value);
+  return formatKM(value);
 };
 
 const capitalize = (value: string) => {

--- a/frontend/src/containers/map/content/details/tables/global-regional/index.tsx
+++ b/frontend/src/containers/map/content/details/tables/global-regional/index.tsx
@@ -168,7 +168,6 @@ const GlobalRegionalTable: React.FC = () => {
       return {
         location: location.name,
         locationCode: location.code,
-        totalMarineArea: location.totalMarineArea,
         coverage: coveragePercentage,
         area: protectedArea,
         locationType: location.type,

--- a/frontend/src/containers/map/content/details/tables/global-regional/useColumns.tsx
+++ b/frontend/src/containers/map/content/details/tables/global-regional/useColumns.tsx
@@ -15,7 +15,6 @@ import { useMapSearchParams } from '@/containers/map/content/map/sync-settings';
 export type GlobalRegionalTableColumns = {
   location: string;
   locationCode: string;
-  totalMarineArea: number;
   coverage: number;
   locationType: string;
   mpas: number;
@@ -86,20 +85,11 @@ const useColumns = () => {
           </HeaderItem>
         ),
         cell: ({ row }) => {
-          const { totalMarineArea, area: value } = row.original;
+          const { area: value } = row.original;
           const formattedValue = cellFormatter.area(value);
-          let displayValue = formattedValue;
-
-          // In certain circumstances, due to rounding, the formatted value may exceed the
-          // total marine area, mostly in situations where the coverage is nearing 100%.
-          // In this case, we skip the rounding and display the value.
-          if (parseFloat(formattedValue) > totalMarineArea) {
-            displayValue = value.toString();
-          }
-
           return (
             <span>
-              {displayValue} km<sup>2</sup>
+              {formattedValue} km<sup>2</sup>
             </span>
           );
         },


### PR DESCRIPTION
### Overview

This PR makes it so that the same area formatter is used across the app, for consistency purposes. 

**Notes:** 
- This PR also reverts the check that ensures an area displayed in the details tables does not exceed the total marine area  
  - This is no longer applicable  
- There's some discussion going on about how to deal with values too close to 0 (which would get rounded to 0) as well as upper values  
  - This is out of scope, but related. 

### Feature relevant tickets

[SKY30-298](https://vizzuality.atlassian.net/browse/SKY30-298)

[SKY30-298]: https://vizzuality.atlassian.net/browse/SKY30-298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ