### PR TITLE
Set the new staging subdomain

### DIFF
--- a/infrastructure/base/vars/terraform.tfvars
+++ b/infrastructure/base/vars/terraform.tfvars
@@ -9,7 +9,7 @@ staging_project_name    = "x30-dev"
 production_project_name = "x30-prod"
 
 domain               = "skytruth.org"
-staging_subdomain    = "30x30"              # TMP
+staging_subdomain    = "30x30-dev"
 production_subdomain = "30x30"
 
 uptime_alert_email = "agnieszka.figiel@vizzuality.com"


### PR DESCRIPTION


### Overview

Staging instance is now at https://30x30-dev.skytruth.org/
Production will be at https://30x30.skytruth.org/

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/SKY30-296?atlOrigin=eyJpIjoiZTA2NGM3OTBjMTdlNDQzZDg1M2EzZDc4MjhiN2I5NDUiLCJwIjoiaiJ9

---

## Checklist before submitting

- [x] Meaningful commits and code rebased on `develop`.