### PR TITLE
[SKY30-300] Display 1 km 2 for areas smaller than 1 but bigger than 0

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -50,7 +50,6 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
     "cmdk": "^0.2.0",
-    "d3-format": "^3.1.0",
     "d3-time-format": "^4.1.0",
     "date-fns": "^2.30.0",
     "deck.gl": "8.9.31",

--- a/frontend/src/components/charts/horizontal-bar-chart/index.tsx
+++ b/frontend/src/components/charts/horizontal-bar-chart/index.tsx
@@ -1,10 +1,8 @@
 import { useMemo } from 'react';
 
-import { format } from 'd3-format';
-
 import TooltipButton from '@/components/tooltip-button';
 import { cn } from '@/lib/classnames';
-import { formatPercentage } from '@/lib/utils/formats';
+import { formatPercentage, formatKM } from '@/lib/utils/formats';
 
 const DEFAULT_MAX_PERCENTAGE = 100;
 const PROTECTION_TARGET = 30;
@@ -47,7 +45,7 @@ const HorizontalBarChart: React.FC<HorizontalBarChartProps> = ({
   }, [protectedArea, totalArea]);
 
   const formattedArea = useMemo(() => {
-    return format(',.0f')(totalArea);
+    return formatKM(totalArea);
   }, [totalArea]);
 
   return (

--- a/frontend/src/lib/utils/formats.ts
+++ b/frontend/src/lib/utils/formats.ts
@@ -24,6 +24,8 @@ export function formatPercentage(
 }
 
 export function formatKM(value: number, options?: Intl.NumberFormatOptions) {
+  if (value < 1 && value > 0) return '<1';
+
   const v = Intl.NumberFormat('en-US', {
     notation: 'standard',
     compactDisplay: 'short',

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -11845,7 +11845,6 @@ __metadata:
     class-variance-authority: ^0.7.0
     clsx: ^2.0.0
     cmdk: ^0.2.0
-    d3-format: ^3.1.0
     d3-time-format: ^4.1.0
     date-fns: ^2.30.0
     deck.gl: 8.9.31


### PR DESCRIPTION
### Overview

Some areas are smaller than 1 km2 and due to rounding are displayed as 0 km2. 
This PR tweaks the formatKM function to display areas smaller than 1 km2 as "<1 km2", similar to how percentages are dealt with. 

### Feature relevant tickets

[SKY30-300](https://vizzuality.atlassian.net/browse/SKY30-300)

[SKY30-300]: https://vizzuality.atlassian.net/browse/SKY30-300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ