### PR TITLE
[SKY30-325] knowledge hub: multiple resource types

### DIFF
--- a/frontend/src/components/filters-button/index.tsx
+++ b/frontend/src/components/filters-button/index.tsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useState } from 'react';
 
 import { useForm } from 'react-hook-form';
 
-import { isEqual } from 'lodash-es';
 import { Filter } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
@@ -52,26 +51,25 @@ const FiltersButton: React.FC<FiltersButtonProps> = ({
     setValue('filters', values);
   }, [setValue, values]);
 
-  useEffect(() => {
-    if (isEqual(filters, values)) return;
-    onChange(field, filters);
-  }, [field, filters, values, onChange]);
-
   const handleSelectAll = () => {
     setValue('filters', allFilterValues);
+    onChange(field, allFilterValues);
   };
 
   const handleClearAll = () => {
     setValue('filters', []);
+    onChange(field, []);
   };
 
   const handleOnCheckedChange = (type, checked) => {
     if (checked) {
       const filtersValues = [...filters, type];
       setValue('filters', filtersValues);
+      onChange(field, filtersValues);
     } else {
       const filtersValues = filters.filter((entry) => entry !== type);
       setValue('filters', filtersValues);
+      onChange(field, filtersValues);
     }
   };
 

--- a/frontend/src/components/static-pages/section/index.tsx
+++ b/frontend/src/components/static-pages/section/index.tsx
@@ -29,7 +29,7 @@ export type SectionProps = PropsWithChildren<{
 const Section = forwardRef<HTMLDivElement, SectionProps>(({ borderTop = true, children }, ref) => (
   <div
     ref={ref}
-    className={cn('w-full border-black py-6 px-8 md:mx-auto md:mb-20 md:max-w-7xl md:px-0', {
+    className={cn('w-full border-black px-8 md:mx-auto md:max-w-7xl md:px-0', {
       'border-t': borderTop,
     })}
   >

--- a/frontend/src/containers/knowledge-hub/card-filters/index.tsx
+++ b/frontend/src/containers/knowledge-hub/card-filters/index.tsx
@@ -4,7 +4,6 @@ import { useAtom } from 'jotai';
 import { useResetAtom } from 'jotai/utils';
 import { ArrowDownNarrowWide, ArrowUpNarrowWide } from 'lucide-react';
 
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { cardFiltersAtom } from '@/containers/knowledge-hub/store';
 
 import CardFiltersEcosystems from './ecosystems';
@@ -24,19 +23,6 @@ const CardFilters = (): JSX.Element => {
 
   return (
     <div className="space-y-8">
-      <Popover>
-        <PopoverTrigger asChild>
-          <button
-            type="button"
-            className="flex items-center space-x-1 font-mono text-xs uppercase underline"
-          >
-            Change resource category
-          </button>
-        </PopoverTrigger>
-        <PopoverContent>
-          <CardFiltersResourceTypes />
-        </PopoverContent>
-      </Popover>
       <div className="flex items-center justify-between">
         <div className="flex items-center space-x-8">
           <div className="flex items-center gap-2">
@@ -52,6 +38,7 @@ const CardFilters = (): JSX.Element => {
             </button>
             <span className="font-mono text-xs font-semibold">Name</span>
           </div>
+          <CardFiltersResourceTypes />
           <CardFiltersLanguages />
           <CardFiltersEcosystems />
         </div>

--- a/frontend/src/containers/knowledge-hub/card-filters/resource-types/index.tsx
+++ b/frontend/src/containers/knowledge-hub/card-filters/resource-types/index.tsx
@@ -1,12 +1,8 @@
-import { useCallback } from 'react';
-
 import { useAtom } from 'jotai';
 
-import Icon from '@/components/ui/icon';
+import FiltersButton from '@/components/filters-button';
 import { cardFiltersAtom } from '@/containers/knowledge-hub/store';
-import CheckIcon from '@/styles/icons/check.svg?sprite';
 import { useGetDataToolResourceTypes } from '@/types/generated/data-tool-resource-type';
-import { DataToolResourceType } from 'types/generated/strapi.schemas';
 
 const CardFiltersResourceTypes = (): JSX.Element => {
   const [filters, setFilters] = useAtom(cardFiltersAtom);
@@ -20,29 +16,29 @@ const CardFiltersResourceTypes = (): JSX.Element => {
     }
   );
 
-  const onSelectResourceType = useCallback(
-    (resourceType: DataToolResourceType['name']) => {
-      setFilters((prevFilters) => ({
-        ...prevFilters,
-        resourceType: prevFilters.resourceType === resourceType ? null : resourceType,
-      }));
-    },
-    [setFilters]
-  );
+  const handleFiltersChange = (field, value) => {
+    setFilters((prevFilters) => ({
+      ...prevFilters,
+      [field]: value,
+    }));
+  };
+
+  const options =
+    resourceTypesQuery?.data?.map((resourceType) => ({
+      name: resourceType,
+      value: resourceType,
+    })) || [];
 
   return (
-    <ul className="space-y-1">
-      {resourceTypesQuery.data?.map((resourceType) => (
-        <li
-          key={resourceType}
-          className="flex cursor-pointer items-center space-x-1 text-base font-black hover:underline"
-          onClick={() => onSelectResourceType(resourceType)}
-        >
-          {filters.resourceType === resourceType && <Icon icon={CheckIcon} className="h-3 w-3" />}
-          <span>{resourceType}</span>
-        </li>
-      ))}
-    </ul>
+    <div className="flex items-center font-mono text-xs font-semibold">
+      <FiltersButton
+        field="resourceType"
+        options={options}
+        values={filters?.resourceType}
+        onChange={handleFiltersChange}
+      />
+      <span>Filter by resource type</span>
+    </div>
   );
 };
 

--- a/frontend/src/containers/knowledge-hub/card-list/index.tsx
+++ b/frontend/src/containers/knowledge-hub/card-list/index.tsx
@@ -7,6 +7,7 @@ import CardItem from './card-item';
 
 const CardList = (): JSX.Element => {
   const filters = useAtomValue(cardFiltersAtom);
+
   const dataToolsQuery = useGetDataToolsInfinite(
     {
       sort: filters.name,
@@ -36,7 +37,6 @@ const CardList = (): JSX.Element => {
           if (lastPage.meta.pagination.page < lastPage.meta.pagination.pageCount) {
             return lastPage.meta.pagination.page + 1;
           }
-
           return false;
         },
       },
@@ -45,7 +45,7 @@ const CardList = (): JSX.Element => {
 
   return (
     <div className="min-h-[225px] space-y-8">
-      <ul className="grid-cols:1 my-4 grid gap-10 md:grid-cols-3">
+      <ul className="grid gap-10 md:grid-cols-3">
         {dataToolsQuery.data?.pages?.map((page) => {
           return page?.data?.map((dataTool) => (
             <li key={dataTool.id}>
@@ -54,8 +54,8 @@ const CardList = (): JSX.Element => {
           ));
         })}
       </ul>
-      <div className="flex justify-center">
-        {dataToolsQuery.hasNextPage && (
+      {dataToolsQuery.hasNextPage && (
+        <div className="flex justify-center">
           <button
             type="button"
             className="font-mono text-xs uppercase underline"
@@ -63,8 +63,8 @@ const CardList = (): JSX.Element => {
           >
             Load more
           </button>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/containers/knowledge-hub/store.ts
+++ b/frontend/src/containers/knowledge-hub/store.ts
@@ -8,12 +8,12 @@ import {
 
 export const cardFiltersAtom = atomWithReset<{
   name: 'name:asc' | 'name:desc' | null;
-  resourceType: DataToolResourceType['name'];
+  resourceType: DataToolResourceType['name'][];
   language: DataToolLanguage['name'][];
   ecosystem: DataToolEcosystem['name'][];
 }>({
   name: 'name:asc',
-  resourceType: null,
+  resourceType: [],
   language: [],
   ecosystem: [],
 });

--- a/frontend/src/layouts/static-page.tsx
+++ b/frontend/src/layouts/static-page.tsx
@@ -84,7 +84,7 @@ const StaticPageLayout: React.FC<
       </div>
       <div className="border-x border-black">{hero && <>{hero}</>}</div>
       <div className={cn('border-black', { border: !!hero, 'border-x': !hero })}>
-        <div className="flex w-full flex-col gap-6 py-0 md:mx-auto md:max-w-7xl md:flex-row md:pt-24 md:pl-8">
+        <div className="flex w-full flex-col gap-6 py-6 md:mx-auto md:max-w-7xl md:flex-row md:py-24 md:pl-8">
           {children}
         </div>
       </div>

--- a/frontend/src/pages/knowledge-hub.tsx
+++ b/frontend/src/pages/knowledge-hub.tsx
@@ -1,27 +1,19 @@
 import { useRef } from 'react';
 
-import { useAtomValue } from 'jotai';
-
 import Cta from '@/components/static-pages/cta';
 import Intro from '@/components/static-pages/intro';
 import Section from '@/components/static-pages/section';
 import { PAGES } from '@/constants/pages';
 import CardFilters from '@/containers/knowledge-hub/card-filters';
 import CardList from '@/containers/knowledge-hub/card-list';
-import { cardFiltersAtom } from '@/containers/knowledge-hub/store';
 import Layout, { Content } from '@/layouts/static-page';
 
 const KnowledgeHubPage = () => {
   const sectionRef = useRef<HTMLDivElement>(null);
-  const filters = useAtomValue(cardFiltersAtom);
 
   const handleIntroScrollClick = () => {
     sectionRef?.current?.scrollIntoView({ behavior: 'smooth' });
   };
-
-  const title = filters.resourceType
-    ? `${filters.resourceType.toLocaleLowerCase()} resources`
-    : 'all 30x30 resources';
 
   return (
     <Layout
@@ -50,12 +42,12 @@ const KnowledgeHubPage = () => {
     >
       <Content>
         <Section ref={sectionRef} borderTop={false}>
-          <div className="space-y-7">
+          <div className="space-y-24">
             <h2 className="text-[52px] font-black leading-none">
               I am looking for...
-              <br /> {title}.
+              <br /> Data tools.
             </h2>
-            <div>
+            <div className="space-y-4">
               <CardFilters />
               <CardList />
             </div>


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

![image](https://github.com/Vizzuality/skytruth-30x30/assets/999124/9cffed91-6184-42f4-9404-d62c046e8f73)

This PR moves away the resource types selector from the title to fit along the rest of filters.

Also, this PR addresses:
- fixed loop produced when some filters where applied and the user clicked on _clear filters_ button producing a loop of re-renders. 
- adjusts some margins of the page/containers to be consisntent.

### Designs

https://www.figma.com/file/RQB86KnkGg4UTpqQZ09KBX/30x30-Design-%5BInternal%5D?node-id=2249%3A9160&mode=dev

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/SKY30-325

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.