### PR TITLE
[SKY30-337] fixes initial location without location code

### DIFF
--- a/frontend/src/containers/map/sidebar/main-panel/details/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/details/index.tsx
@@ -19,7 +19,7 @@ const SidebarDetails: React.FC = () => {
 
   const { data: locationsData } = useGetLocations({
     filters: {
-      code: locationCode,
+      code: locationCode || 'GLOB',
     },
     populate: 'members',
   });

--- a/frontend/src/containers/map/sidebar/main-panel/details/location-selector/location-dropdown/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/details/location-selector/location-dropdown/index.tsx
@@ -39,7 +39,8 @@ const LocationDropdown: React.FC<LocationDropdownProps> = ({
     {
       query: {
         queryKey: ['locations', locationCode],
-        select: ({ data }) => data?.[0]?.attributes,
+        select: ({ data }) =>
+          data?.find(({ attributes: { code } }) => code === (locationCode || 'GLOB'))?.attributes,
       },
     }
   );


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

Fixes an issue where the location selected when there was no location code in the URL was random (it depended on the way the API was returning the list as we were always asking for the first location). Now we make sure if there is no location code present, `GLOB` is the default.

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/SKY30-337

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.