### PR TITLE
[SKY30-334] displays EEZ names hovering the map

### DIFF
--- a/frontend/src/containers/map/content/map/index.tsx
+++ b/frontend/src/containers/map/content/map/index.tsx
@@ -103,7 +103,6 @@ const MainMap: React.FC = () => {
         );
 
         setPopup({});
-        return null;
       }
 
       if (
@@ -122,11 +121,17 @@ const MainMap: React.FC = () => {
 
   const handleMouseMove = useCallback(
     (e: Parameters<ComponentProps<typeof Map>['onMouseOver']>[0]) => {
-      if (popup?.features?.length) return;
+      if (!e.features.length) {
+        setPopup({});
+      }
 
-      if (e.features.length > 0) {
+      if (e?.features?.length > 0) {
         if (!drawState.active) {
           setCursor('pointer');
+        }
+
+        if (e.type === 'mousemove') {
+          setPopup({ ...e });
         }
 
         if (hoveredPolygonId.current !== null) {
@@ -155,7 +160,7 @@ const MainMap: React.FC = () => {
         }
       }
     },
-    [map, hoveredPolygonId, drawState.active, popup]
+    [map, hoveredPolygonId, drawState.active, setPopup]
   );
 
   const handleMouseLeave = useCallback(() => {
@@ -170,7 +175,8 @@ const MainMap: React.FC = () => {
         { hover: false }
       );
     }
-  }, [map, hoveredPolygonId, popup]);
+    setPopup({});
+  }, [map, hoveredPolygonId, popup, setPopup]);
 
   const initialViewState: ComponentProps<typeof Map>['initialViewState'] = useMemo(() => {
     if (URLBbox) {
@@ -231,6 +237,8 @@ const MainMap: React.FC = () => {
     }
   }, [map, popup]);
 
+  const disableMouseMove = popup.type === 'click' && popup.features?.length;
+
   return (
     <div className="absolute left-0 h-full w-full border-r border-b border-black">
       <Map
@@ -239,7 +247,7 @@ const MainMap: React.FC = () => {
         interactiveLayerIds={!drawState.active && !drawState.feature ? layersInteractiveIds : []}
         onClick={handleMapClick}
         onMoveEnd={handleMoveEnd}
-        onMouseMove={handleMouseMove}
+        onMouseMove={!disableMouseMove && handleMouseMove}
         onMouseLeave={handleMouseLeave}
         attributionControl={false}
         cursor={cursor}

--- a/frontend/src/containers/map/content/map/popup/index.tsx
+++ b/frontend/src/containers/map/content/map/popup/index.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { Popup } from 'react-map-gl';
 
 import { useAtomValue, useSetAtom } from 'jotai';
+import { useKey } from 'rooks';
 
 import Icon from '@/components/ui/icon';
 import {
@@ -14,6 +15,7 @@ import {
 } from '@/components/ui/select';
 import PopupItem from '@/containers/map/content/map/popup/item';
 import { layersInteractiveAtom, popupAtom } from '@/containers/map/store';
+import { cn } from '@/lib/classnames';
 import CloseIcon from '@/styles/icons/close.svg?sprite';
 import { useGetLayers } from '@/types/generated/layer';
 
@@ -84,6 +86,11 @@ const PopupContainer = () => {
     }
   }, [layersInteractiveData]);
 
+  useKey('Escape', closePopup);
+
+  const isHoveredTooltip = popup?.type === 'mousemove';
+  const isClickedTooltip = popup?.type === 'click';
+
   if (!Object.keys(popup).length || !popup?.features?.length) return null;
 
   return (
@@ -94,15 +101,19 @@ const PopupContainer = () => {
       closeButton={false}
       maxWidth="300px"
       onClose={closePopup}
-      className="min-w-[250px]"
+      className={cn({
+        'min-w-[250px]': !isHoveredTooltip,
+      })}
     >
       <div className="space-y-2 p-4">
-        <div className="flex justify-end">
-          <button onClick={closePopup}>
-            <Icon icon={CloseIcon} className="h-3 w-3 fill-black" />
-          </button>
-        </div>
-        {availableSources.length > 1 && (
+        {!isHoveredTooltip && (
+          <div className="flex justify-end">
+            <button onClick={closePopup}>
+              <Icon icon={CloseIcon} className="h-3 w-3 fill-black" />
+            </button>
+          </div>
+        )}
+        {isClickedTooltip && availableSources.length > 1 && (
           <Select
             onValueChange={(v) => {
               setSelectedLayerId(+v);
@@ -121,7 +132,12 @@ const PopupContainer = () => {
             </SelectContent>
           </Select>
         )}
-        {selectedLayerId && <PopupItem id={selectedLayerId} />}
+        {isHoveredTooltip && (
+          <div className="font-mono text-sm text-gray-500">
+            {popup.features[0].properties?.GEONAME}
+          </div>
+        )}
+        {isClickedTooltip && selectedLayerId && <PopupItem id={selectedLayerId} />}
       </div>
     </Popup>
   );


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

![image](https://github.com/Vizzuality/skytruth-30x30/assets/999124/f9ea4ce7-9634-408d-8975-0e2a38d428ee)

Additionally, adds a listener to close the popup when the user presses the `Escape` key.


### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/SKY30-334

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.