### PR TITLE
[SKY30-343] Split Protection Levels widget into two  

### DIFF
--- a/frontend/src/constants/fishing-protection-chart-colors.ts
+++ b/frontend/src/constants/fishing-protection-chart-colors.ts
@@ -1,0 +1,3 @@
+export const FISHING_PROTECTION_CHART_COLORS = {
+  highly: '#2768B4',
+};

--- a/frontend/src/constants/protection-types-chart-colors.ts
+++ b/frontend/src/constants/protection-types-chart-colors.ts
@@ -1,4 +1,3 @@
 export const PROTECTION_TYPES_CHART_COLORS = {
   'fully-highly-protected': '#FD8E28',
-  highly: '#D9635C',
 };

--- a/frontend/src/containers/map/sidebar/main-panel/details/widgets/fishing-protection/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/details/widgets/fishing-protection/index.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 
 import HorizontalBarChart from '@/components/charts/horizontal-bar-chart';
 import Widget from '@/components/widget';
-import { PROTECTION_TYPES_CHART_COLORS } from '@/constants/protection-types-chart-colors';
+import { FISHING_PROTECTION_CHART_COLORS } from '@/constants/fishing-protection-chart-colors';
 import { useGetLocations } from '@/types/generated/location';
 import type { LocationGroupsDataItemAttributes } from '@/types/generated/strapi.schemas';
 
@@ -23,14 +23,14 @@ const ProtectionTypesWidget: React.FC<ProtectionTypesWidgetProps> = ({ location 
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       populate: {
-        mpaa_protection_level_stats: {
+        fishing_protection_level_stats: {
           filters: {
-            mpaa_protection_level: {
-              slug: 'fully-highly-protected',
+            fishing_protection_level: {
+              slug: 'highly',
             },
           },
           populate: {
-            mpaa_protection_level: '*',
+            fishing_protection_level: '*',
           },
         },
       },
@@ -54,21 +54,21 @@ const ProtectionTypesWidget: React.FC<ProtectionTypesWidgetProps> = ({ location 
       return {
         title: label,
         slug: protectionLevel.slug,
-        background: PROTECTION_TYPES_CHART_COLORS[protectionLevel.slug],
+        background: FISHING_PROTECTION_CHART_COLORS[protectionLevel.slug],
         totalArea: location.totalMarineArea,
         protectedArea: stats?.area,
         info: protectionLevel.info,
       };
     };
 
-    const parsedMpaaProtectionLevelData =
-      protectionLevelsData[0]?.attributes?.mpaa_protection_level_stats?.data?.map((entry) => {
+    const parsedFishingProtectionLevelData =
+      protectionLevelsData[0]?.attributes?.fishing_protection_level_stats?.data?.map((entry) => {
         const stats = entry?.attributes;
-        const protectionLevel = stats?.mpaa_protection_level?.data.attributes;
-        return parsedProtectionLevel('Fully or highly protected', protectionLevel, stats);
+        const protectionLevel = stats?.fishing_protection_level?.data.attributes;
+        return parsedProtectionLevel('Highly protected from fishing', protectionLevel, stats);
       });
 
-    return parsedMpaaProtectionLevelData;
+    return parsedFishingProtectionLevelData;
   }, [location, protectionLevelsData]);
 
   const noData = !widgetChartData.length;
@@ -77,7 +77,7 @@ const ProtectionTypesWidget: React.FC<ProtectionTypesWidgetProps> = ({ location 
 
   return (
     <Widget
-      title="Marine Conservation Protection Levels"
+      title="Fishing Protection"
       lastUpdated={protectionLevelsData[0]?.attributes?.updatedAt}
       noData={noData}
       loading={loading}

--- a/frontend/src/containers/map/sidebar/main-panel/details/widgets/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/details/widgets/index.tsx
@@ -8,6 +8,7 @@ import { useGetLocations } from '@/types/generated/location';
 import HabitatWidget from './habitat';
 import MarineConservationWidget from './marine-conservation';
 import ProtectionTypesWidget from './protection-types';
+import FishingProtectionWidget from './fishing-protection';
 
 const DetailsWidgets: React.FC = () => {
   const {
@@ -31,6 +32,7 @@ const DetailsWidgets: React.FC = () => {
     >
       <MarineConservationWidget location={locationsData?.data[0]?.attributes} />
       <ProtectionTypesWidget location={locationsData?.data[0]?.attributes} />
+      <FishingProtectionWidget location={locationsData?.data[0]?.attributes} />
       {/* <EstablishmentStagesWidget location={locationsData?.data[0]?.attributes} /> */}
       <HabitatWidget location={locationsData?.data[0]?.attributes} />
     </div>

--- a/frontend/src/containers/map/sidebar/main-panel/details/widgets/protection-types/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/details/widgets/protection-types/index.tsx
@@ -33,16 +33,6 @@ const ProtectionTypesWidget: React.FC<ProtectionTypesWidgetProps> = ({ location 
             mpaa_protection_level: '*',
           },
         },
-        fishing_protection_level_stats: {
-          filters: {
-            fishing_protection_level: {
-              slug: 'highly',
-            },
-          },
-          populate: {
-            fishing_protection_level: '*',
-          },
-        },
       },
       'pagination[limit]': -1,
     },
@@ -78,14 +68,7 @@ const ProtectionTypesWidget: React.FC<ProtectionTypesWidgetProps> = ({ location 
         return parsedProtectionLevel('Fully or highly protected', protectionLevel, stats);
       });
 
-    const parsedFishingProtectionLevelData =
-      protectionLevelsData[0]?.attributes?.fishing_protection_level_stats?.data?.map((entry) => {
-        const stats = entry?.attributes;
-        const protectionLevel = stats?.fishing_protection_level?.data.attributes;
-        return parsedProtectionLevel('Highly protected from fishing', protectionLevel, stats);
-      });
-
-    return [...parsedMpaaProtectionLevelData, ...parsedFishingProtectionLevelData];
+    return [...parsedMpaaProtectionLevelData];
   }, [location, protectionLevelsData]);
 
   const noData = !widgetChartData.length;


### PR DESCRIPTION
### Overview

This PR splits the Protection Levels widget into two: 
- Marine Conservation **Protection Levels** 
- **Fishing Protection**  

The new widget is simply a duplicate of the first, to make things easier, with: 
- Relevant parameters from the query removed  
- New color for the chart  

The original support for adding new entries and setting colors has been preserved, both for speeding up the task and to make it easier in case we revert and/or add new entries to the widget in the future. 

### Feature relevant tickets

[SKY30-343](https://vizzuality.atlassian.net/browse/SKY30-343)

[SKY30-343]: https://vizzuality.atlassian.net/browse/SKY30-343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ