### PR TITLE
[SKY30-344] Habitats widget changes

### DIFF
--- a/frontend/src/components/charts/horizontal-bar-chart/index.tsx
+++ b/frontend/src/components/charts/horizontal-bar-chart/index.tsx
@@ -60,7 +60,7 @@ const HorizontalBarChart: React.FC<HorizontalBarChartProps> = ({
           {info && <TooltipButton text={info} />}
         </span>
         <span>
-          of {formattedArea} km<sup>2</sup>
+          out of {formattedArea} km<sup>2</sup>
         </span>
       </div>
       <div className="relative my-2 flex h-3.5">

--- a/frontend/src/constants/habitat-chart-colors.ts
+++ b/frontend/src/constants/habitat-chart-colors.ts
@@ -1,8 +1,8 @@
 export const HABITAT_CHART_COLORS = {
-  'warm-water corals': '#AD6CFF',
-  'cold-water corals': '#04D8F4',
+  'warm-water corals': '#EC7667',
+  'cold-water corals': '#3ACBF9',
   mangroves: '#DFC700',
-  seagrasses: '#02B048',
-  saltmarshes: '#717B00',
+  seagrasses: '#2DBA66',
+  saltmarshes: '#6D7600',
   seamounts: '#884B02',
 };


### PR DESCRIPTION
### Overview

**In this PR:**  
- Updated the proportion of habitat widget's bar colors to match the design 
- added the word “out” in the label below each habitat percentage for example “out of 149,887 km2" 
  _Note: as of now this would apply to the other widgets as well, but I believe this should be addressed when addressing [SKY30-280](https://vizzuality.atlassian.net/browse/SKY30-280)_

![Screenshot 2024-04-08 at 07 00 32](https://github.com/Vizzuality/skytruth-30x30/assets/6273795/36084432-7256-4390-91d2-f94772e6d821)


### Feature relevant tickets

[SKY30-344](https://vizzuality.atlassian.net/browse/SKY30-344)

[SKY30-344]: https://vizzuality.atlassian.net/browse/SKY30-344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SKY30-280]: https://vizzuality.atlassian.net/browse/SKY30-280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ