### PR TITLE
[SKY30-342] Marine conservation coverage widget changes

### DIFF
--- a/frontend/src/components/charts/conservation-chart/index.tsx
+++ b/frontend/src/components/charts/conservation-chart/index.tsx
@@ -228,7 +228,7 @@ const ConservationChart: React.FC<ConservationChartProps> = ({ className, data }
             type="monotone"
             strokeWidth={2}
             dataKey="historical"
-            stroke={twTheme.colors.blue[600]}
+            stroke={twTheme.colors.violet as string}
             dot={false}
             activeDot={false}
           />
@@ -238,7 +238,7 @@ const ConservationChart: React.FC<ConservationChartProps> = ({ className, data }
             strokeWidth={2}
             strokeDasharray="4 4"
             dataKey="projected"
-            stroke={twTheme.colors.blue[600]}
+            stroke={twTheme.colors.violet as string}
             dot={false}
             activeDot={false}
           />
@@ -246,7 +246,7 @@ const ConservationChart: React.FC<ConservationChartProps> = ({ className, data }
             {chartData.map((entry, index) => (
               <Cell
                 stroke="black"
-                fill={entry?.active ? '#4879FF' : 'transparent'}
+                fill={entry?.active ? 'black' : 'transparent'}
                 key={`cell-${index}`}
               />
             ))}

--- a/frontend/src/components/charts/conservation-chart/index.tsx
+++ b/frontend/src/components/charts/conservation-chart/index.tsx
@@ -24,6 +24,7 @@ import ChartTooltip from './tooltip';
 
 type ConservationChartProps = {
   className?: string;
+  displayTarget?: boolean;
   data: {
     year?: number;
     percentage: number;
@@ -37,7 +38,11 @@ type ConservationChartProps = {
 const TARGET_YEAR = 2030;
 const MAX_NUM_YEARS = 20;
 
-const ConservationChart: React.FC<ConservationChartProps> = ({ className, data }) => {
+const ConservationChart: React.FC<ConservationChartProps> = ({
+  className,
+  displayTarget = true,
+  data,
+}) => {
   const barChartData = useMemo(() => {
     // Last year of data available
     const lastEntryYear = data[data.length - 1]?.year;
@@ -164,34 +169,36 @@ const ConservationChart: React.FC<ConservationChartProps> = ({ className, data }
       <ResponsiveContainer>
         <ComposedChart data={chartData}>
           <CartesianGrid vertical={false} strokeDasharray="3 3" />
-          <ReferenceLine
-            xAxisId={1}
-            y={30}
-            label={(props) => {
-              const { viewBox } = props;
-              return (
-                <g>
-                  <text {...viewBox} x={viewBox.x + 5} y={viewBox.y - 2}>
-                    30x30 Target
-                  </text>
-                  <foreignObject
-                    {...viewBox}
-                    x={viewBox.x + 90}
-                    y={viewBox.y - 17}
-                    width="160"
-                    height="160"
-                  >
-                    <TooltipButton
-                      text={dataInfo?.attributes.content}
-                      className="mt-1 hover:bg-transparent"
-                    />
-                  </foreignObject>
-                </g>
-              );
-            }}
-            stroke="#FD8E28"
-            strokeDasharray="3 3"
-          />
+          {displayTarget && (
+            <ReferenceLine
+              xAxisId={1}
+              y={30}
+              label={(props) => {
+                const { viewBox } = props;
+                return (
+                  <g>
+                    <text {...viewBox} x={viewBox.x + 5} y={viewBox.y - 2}>
+                      30x30 Target
+                    </text>
+                    <foreignObject
+                      {...viewBox}
+                      x={viewBox.x + 90}
+                      y={viewBox.y - 17}
+                      width="160"
+                      height="160"
+                    >
+                      <TooltipButton
+                        text={dataInfo?.attributes.content}
+                        className="mt-1 hover:bg-transparent"
+                      />
+                    </foreignObject>
+                  </g>
+                );
+              }}
+              stroke="#FD8E28"
+              strokeDasharray="3 3"
+            />
+          )}
           <ReferenceLine
             xAxisId={1}
             x={firstYearData.year - 0.4}

--- a/frontend/src/components/charts/conservation-chart/legend/index.tsx
+++ b/frontend/src/components/charts/conservation-chart/legend/index.tsx
@@ -2,11 +2,11 @@ const ChartLegend = () => {
   return (
     <div className="ml-8 mt-2 flex justify-between gap-3">
       <span className="inline-flex items-center gap-3">
-        <span className="block h-[2px] w-10 border-b-2 border-blue"></span>
+        <span className="block h-[2px] w-10 border-b-2 border-violet"></span>
         <span>Historical Trend</span>
       </span>
       <span className="inline-flex items-center gap-3">
-        <span className="block h-[2px] w-10 border-b-2 border-dashed border-blue"></span>
+        <span className="block h-[2px] w-10 border-b-2 border-dashed border-violet"></span>
         <span>Future Projection</span>
       </span>
     </div>

--- a/frontend/src/components/widget/index.tsx
+++ b/frontend/src/components/widget/index.tsx
@@ -4,12 +4,15 @@ import { timeFormat } from 'd3-time-format';
 
 import { cn } from '@/lib/classnames';
 
+import TooltipButton from '../tooltip-button';
+
 import Loading from './loading';
 import NoData from './no-data';
 
 type WidgetProps = {
   className?: string;
   title?: string;
+  tooltip?: string;
   lastUpdated?: string;
   noData?: boolean;
   loading?: boolean;
@@ -21,6 +24,7 @@ const Widget: React.FC<PropsWithChildren<WidgetProps>> = ({
   className,
   title,
   lastUpdated,
+  tooltip,
   noData = false,
   loading = false,
   error = false,
@@ -37,8 +41,9 @@ const Widget: React.FC<PropsWithChildren<WidgetProps>> = ({
   return (
     <div className={cn('py-4 px-4 md:px-8', className)}>
       <div className="pt-2">
-        <span className="flex justify-between">
+        <span className="flex">
           {title && <h2 className="font-sans text-xl font-bold">{title}</h2>}
+          {tooltip && <TooltipButton text={tooltip} className="mt-1 hover:bg-transparent" />}
         </span>
         {!showNoData && lastUpdated && (
           <span className="text-xs">Data last updated: {formattedLastUpdated}</span>

--- a/frontend/src/containers/map/sidebar/main-panel/details/widgets/establishment-stages/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/details/widgets/establishment-stages/index.tsx
@@ -7,6 +7,8 @@ import Widget from '@/components/widget';
 import { useGetMpaaEstablishmentStageStats } from '@/types/generated/mpaa-establishment-stage-stat';
 import type { LocationGroupsDataItemAttributes } from '@/types/generated/strapi.schemas';
 
+import useTooltips from '../useTooltips';
+
 type EstablishmentStagesWidgetProps = {
   location: LocationGroupsDataItemAttributes;
 };
@@ -64,6 +66,8 @@ const EstablishmentStagesWidget: React.FC<EstablishmentStagesWidgetProps> = ({ l
     }
   );
 
+  const tooltips = useTooltips();
+
   // Merge OECM and MPA stats
   const mergedEstablishmentStagesStats = useMemo(() => {
     if (!establishmentStagesData.length) return [];
@@ -113,6 +117,7 @@ const EstablishmentStagesWidget: React.FC<EstablishmentStagesWidgetProps> = ({ l
   return (
     <Widget
       title="Marine Conservation Establishment Stages"
+      tooltip={tooltips?.['establishmentStages']}
       lastUpdated={dataLastUpdate}
       noData={noData}
       loading={loading}

--- a/frontend/src/containers/map/sidebar/main-panel/details/widgets/fishing-protection/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/details/widgets/fishing-protection/index.tsx
@@ -6,6 +6,8 @@ import { FISHING_PROTECTION_CHART_COLORS } from '@/constants/fishing-protection-
 import { useGetLocations } from '@/types/generated/location';
 import type { LocationGroupsDataItemAttributes } from '@/types/generated/strapi.schemas';
 
+import useTooltips from '../useTooltips';
+
 type ProtectionTypesWidgetProps = {
   location: LocationGroupsDataItemAttributes;
 };
@@ -46,6 +48,8 @@ const ProtectionTypesWidget: React.FC<ProtectionTypesWidgetProps> = ({ location 
     }
   );
 
+  const tooltips = useTooltips();
+
   // Parse data to display in the chart
   const widgetChartData = useMemo(() => {
     if (!protectionLevelsData.length) return [];
@@ -78,6 +82,7 @@ const ProtectionTypesWidget: React.FC<ProtectionTypesWidgetProps> = ({ location 
   return (
     <Widget
       title="Fishing Protection"
+      tooltip={tooltips?.['fishingProtection']}
       lastUpdated={protectionLevelsData[0]?.attributes?.updatedAt}
       noData={noData}
       loading={loading}

--- a/frontend/src/containers/map/sidebar/main-panel/details/widgets/habitat/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/details/widgets/habitat/index.tsx
@@ -6,6 +6,8 @@ import { HABITAT_CHART_COLORS } from '@/constants/habitat-chart-colors';
 import { useGetHabitatStats } from '@/types/generated/habitat-stat';
 import type { LocationGroupsDataItemAttributes } from '@/types/generated/strapi.schemas';
 
+import useTooltips from '../useTooltips';
+
 type HabitatWidgetProps = {
   location: LocationGroupsDataItemAttributes;
 };
@@ -53,6 +55,8 @@ const HabitatWidget: React.FC<HabitatWidgetProps> = ({ location }) => {
     }
   );
 
+  const tooltips = useTooltips();
+
   const widgetChartData = useMemo(() => {
     if (!habitatStatsData) return [];
 
@@ -78,6 +82,7 @@ const HabitatWidget: React.FC<HabitatWidgetProps> = ({ location }) => {
   return (
     <Widget
       title="Proportion of Habitat within Protected and Conserved Areas"
+      tooltip={tooltips?.['habitats']}
       lastUpdated={dataLastUpdate}
       noData={noData}
       loading={loading}

--- a/frontend/src/containers/map/sidebar/main-panel/details/widgets/marine-conservation/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/details/widgets/marine-conservation/index.tsx
@@ -123,6 +123,8 @@ const MarineConservationWidget: React.FC<MarineConservationWidgetProps> = ({ loc
   const noData = !chartData.length;
   const loading = isFetchingProtectionStatsData || isFetchingDataLastUpdate;
 
+  const displayTarget = location?.code === 'GLOB';
+
   return (
     <Widget
       title="Marine Conservation Coverage"
@@ -148,7 +150,11 @@ const MarineConservationWidget: React.FC<MarineConservationWidgetProps> = ({ loc
           </span>
         </div>
       )}
-      <ConservationChart className="-ml-8 aspect-[16/10]" data={chartData} />
+      <ConservationChart
+        className="-ml-8 aspect-[16/10]"
+        displayTarget={displayTarget}
+        data={chartData}
+      />
     </Widget>
   );
 };

--- a/frontend/src/containers/map/sidebar/main-panel/details/widgets/marine-conservation/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/details/widgets/marine-conservation/index.tsx
@@ -146,10 +146,7 @@ const MarineConservationWidget: React.FC<MarineConservationWidgetProps> = ({ loc
           </span>
           <span className="space-x-1 text-xs">
             <span>
-              {stats?.protectedArea} out of {stats?.totalArea}
-            </span>
-            <span>
-              km<sup>2</sup>
+              {stats?.protectedArea} km<sup>2</sup> out of {stats?.totalArea} km<sup>2</sup>
             </span>
           </span>
         </div>

--- a/frontend/src/containers/map/sidebar/main-panel/details/widgets/marine-conservation/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/details/widgets/marine-conservation/index.tsx
@@ -9,6 +9,8 @@ import { formatPercentage } from '@/lib/utils/formats';
 import { useGetProtectionCoverageStats } from '@/types/generated/protection-coverage-stat';
 import type { LocationGroupsDataItemAttributes } from '@/types/generated/strapi.schemas';
 
+import useTooltips from '../useTooltips';
+
 type MarineConservationWidgetProps = {
   location: LocationGroupsDataItemAttributes;
 };
@@ -17,7 +19,7 @@ const MarineConservationWidget: React.FC<MarineConservationWidgetProps> = ({ loc
   const defaultQueryParams = {
     filters: {
       location: {
-        code: location?.code,
+        code: location?.code || 'GLOB',
       },
     },
   };
@@ -58,6 +60,8 @@ const MarineConservationWidget: React.FC<MarineConservationWidgetProps> = ({ loc
       },
     }
   );
+
+  const tooltips = useTooltips();
 
   const mergedProtectionStats = useMemo(() => {
     if (!protectionStatsData.length) return null;
@@ -122,12 +126,12 @@ const MarineConservationWidget: React.FC<MarineConservationWidgetProps> = ({ loc
 
   const noData = !chartData.length;
   const loading = isFetchingProtectionStatsData || isFetchingDataLastUpdate;
-
   const displayTarget = location?.code === 'GLOB';
 
   return (
     <Widget
       title="Marine Conservation Coverage"
+      tooltip={tooltips?.['marineConservation']}
       lastUpdated={dataLastUpdate}
       noData={noData}
       loading={loading}

--- a/frontend/src/containers/map/sidebar/main-panel/details/widgets/marine-conservation/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/details/widgets/marine-conservation/index.tsx
@@ -131,14 +131,14 @@ const MarineConservationWidget: React.FC<MarineConservationWidgetProps> = ({ loc
       loading={loading}
     >
       {stats && (
-        <div className="mt-6 mb-4 flex flex-col text-blue">
+        <div className="mt-6 mb-4 flex flex-col">
           <span className="space-x-1">
             <span className="text-[64px] font-bold leading-[80%]">
               {stats?.protectedPercentage}
             </span>
             <span className="text-lg">%</span>
           </span>
-          <span className="space-x-1 text-lg  ">
+          <span className="space-x-1 text-xs">
             <span>
               {stats?.protectedArea} out of {stats?.totalArea}
             </span>

--- a/frontend/src/containers/map/sidebar/main-panel/details/widgets/marine-conservation/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/details/widgets/marine-conservation/index.tsx
@@ -88,10 +88,12 @@ const MarineConservationWidget: React.FC<MarineConservationWidgetProps> = ({ loc
       displayPercentageSign: false,
     });
     const protectedAreaFormatted = formatKM(protectedArea);
+    const totalAreaFormatted = formatKM(totalArea);
 
     return {
       protectedPercentage: percentageFormatted,
       protectedArea: protectedAreaFormatted,
+      totalArea: totalAreaFormatted,
     };
   }, [location, mergedProtectionStats]);
 
@@ -137,7 +139,9 @@ const MarineConservationWidget: React.FC<MarineConservationWidgetProps> = ({ loc
             <span className="text-lg">%</span>
           </span>
           <span className="space-x-1 text-lg  ">
-            <span>{stats?.protectedArea}</span>
+            <span>
+              {stats?.protectedArea} out of {stats?.totalArea}
+            </span>
             <span>
               km<sup>2</sup>
             </span>

--- a/frontend/src/containers/map/sidebar/main-panel/details/widgets/protection-types/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/details/widgets/protection-types/index.tsx
@@ -6,6 +6,8 @@ import { PROTECTION_TYPES_CHART_COLORS } from '@/constants/protection-types-char
 import { useGetLocations } from '@/types/generated/location';
 import type { LocationGroupsDataItemAttributes } from '@/types/generated/strapi.schemas';
 
+import useTooltips from '../useTooltips';
+
 type ProtectionTypesWidgetProps = {
   location: LocationGroupsDataItemAttributes;
 };
@@ -46,6 +48,8 @@ const ProtectionTypesWidget: React.FC<ProtectionTypesWidgetProps> = ({ location 
     }
   );
 
+  const tooltips = useTooltips();
+
   // Parse data to display in the chart
   const widgetChartData = useMemo(() => {
     if (!protectionLevelsData.length) return [];
@@ -78,6 +82,7 @@ const ProtectionTypesWidget: React.FC<ProtectionTypesWidgetProps> = ({ location 
   return (
     <Widget
       title="Marine Conservation Protection Levels"
+      tooltip={tooltips?.['protectionTypes']}
       lastUpdated={protectionLevelsData[0]?.attributes?.updatedAt}
       noData={noData}
       loading={loading}

--- a/frontend/src/containers/map/sidebar/main-panel/details/widgets/useTooltips.ts
+++ b/frontend/src/containers/map/sidebar/main-panel/details/widgets/useTooltips.ts
@@ -1,0 +1,31 @@
+import { useGetDataInfos } from '@/types/generated/data-info';
+
+const TOOLTIP_MAPPING = {
+  marineConservation: 'coverage-widget',
+};
+
+const useTooltips = () => {
+  const { data: dataInfo } = useGetDataInfos(
+    {},
+    {
+      query: {
+        select: ({ data }) => data,
+        placeholderData: { data: [] },
+      },
+    }
+  );
+
+  const tooltips = {};
+
+  Object.entries(TOOLTIP_MAPPING).map(([key, value]) => {
+    const tooltip = dataInfo.find(({ attributes }) => attributes.slug === value)?.attributes
+      ?.content;
+
+    if (!tooltip) return;
+    tooltips[key] = tooltip;
+  });
+
+  return tooltips;
+};
+
+export default useTooltips;

--- a/frontend/src/containers/map/sidebar/main-panel/details/widgets/useTooltips.ts
+++ b/frontend/src/containers/map/sidebar/main-panel/details/widgets/useTooltips.ts
@@ -2,6 +2,10 @@ import { useGetDataInfos } from '@/types/generated/data-info';
 
 const TOOLTIP_MAPPING = {
   marineConservation: 'coverage-widget',
+  establishmentStages: 'establishment-stages-widget',
+  habitats: 'habitats-widget',
+  protectionTypes: 'protection-types-widget',
+  fishingProtection: 'fishing-protection-widget',
 };
 
 const useTooltips = () => {


### PR DESCRIPTION
### Overview

**In this PR:**  
- Marine Conservation Coverage widget changes
  - Small color changes to the header  
  - Text sizing changed to the text displayed below the title  
  - Small change to the text displayed below the title  
  - Chart colors change  
  - 30% target only displayed for GLOB  
  - Added tooltips next to the widgets title 

**Note:**  
About the Tooltips button next to the widgets title, I followed the pattern in other components. I think this should be simplified, mostly due to the multiple instances of the `useTooltips` hooks, but in the future as part of a go at code tidying. I did start revamping this but it looked like it would take longer than expected, and because of the timeframe and possibility of introducing even more bugs this should probably be addressed as a chore in the future. 

All widgets have support for tooltips next to the title, I added the respective entries (blanked, won't be displayed) to CMS staging just to ensure Science is aware of them when they come back, following the original pattern (we had this kind of functionality before. Ish. The entries were already there. )

### Screenshot

![Screenshot 2024-04-09 at 11 46 17](https://github.com/Vizzuality/skytruth-30x30/assets/6273795/b93d6a24-26e0-410b-a2da-4ff37ded9705)

### Feature relevant tickets

[SKY30-342](https://vizzuality.atlassian.net/browse/SKY30-342)

[SKY30-342]: https://vizzuality.atlassian.net/browse/SKY30-342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ