### PR TITLE
[SKY30-350] Fix for incorrect data when locationCode in the query doesn't exist

### DIFF
--- a/frontend/src/components/widget/index.tsx
+++ b/frontend/src/components/widget/index.tsx
@@ -2,10 +2,10 @@ import { ComponentProps, PropsWithChildren, useMemo } from 'react';
 
 import { timeFormat } from 'd3-time-format';
 
+import { cn } from '@/lib/classnames';
+
 import Loading from './loading';
 import NoData from './no-data';
-
-import { cn } from '@/lib/classnames';
 
 type WidgetProps = {
   className?: string;

--- a/frontend/src/containers/map/content/details/index.tsx
+++ b/frontend/src/containers/map/content/details/index.tsx
@@ -12,7 +12,7 @@ import { getGetLocationsQueryOptions, useGetLocations } from '@/types/generated/
 const MapDetails: React.FC = () => {
   const [, setSettings] = useSyncMapContentSettings();
   const {
-    query: { locationCode },
+    query: { locationCode = 'GLOB' },
   } = useRouter();
 
   const locationsQuery = useGetLocations(

--- a/frontend/src/containers/map/content/details/tables/global-regional/index.tsx
+++ b/frontend/src/containers/map/content/details/tables/global-regional/index.tsx
@@ -9,7 +9,7 @@ import type { LocationListResponseDataItem } from '@/types/generated/strapi.sche
 
 const GlobalRegionalTable: React.FC = () => {
   const {
-    query: { locationCode },
+    query: { locationCode = 'GLOB' },
   } = useRouter();
 
   const globalLocationQuery = useGetLocations(

--- a/frontend/src/containers/map/content/details/tables/national-highseas/index.tsx
+++ b/frontend/src/containers/map/content/details/tables/national-highseas/index.tsx
@@ -11,7 +11,7 @@ import { MpaProtectionCoverageStatListResponseDataItem } from '@/types/generated
 
 const NationalHighseasTable: React.FC = () => {
   const {
-    query: { locationCode },
+    query: { locationCode = 'GLOB' },
   } = useRouter();
 
   const locationsQuery = useGetLocations(

--- a/frontend/src/containers/map/content/map/layer-manager/item.tsx
+++ b/frontend/src/containers/map/content/map/layer-manager/item.tsx
@@ -23,7 +23,7 @@ const LayerManagerItem = ({ id, beforeId, settings }: LayerManagerItemProps) => 
   });
   const [, setLayersInteractive] = useAtom(layersInteractiveAtom);
   const [, setLayersInteractiveIds] = useAtom(layersInteractiveIdsAtom);
-  const { locationCode } = useParams();
+  const { locationCode = 'GLOB' } = useParams();
 
   const handleAddMapboxLayer = useCallback(
     ({ styles }: Config) => {

--- a/frontend/src/containers/map/sidebar/main-panel/details/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/details/index.tsx
@@ -13,13 +13,13 @@ import DetailsWidgets from './widgets';
 
 const SidebarDetails: React.FC = () => {
   const {
-    query: { locationCode },
+    query: { locationCode = 'GLOB' },
   } = useRouter();
   const [{ showDetails }] = useSyncMapContentSettings();
 
   const { data: locationsData } = useGetLocations({
     filters: {
-      code: locationCode || 'GLOB',
+      code: locationCode,
     },
     populate: 'members',
   });

--- a/frontend/src/containers/map/sidebar/main-panel/details/location-selector/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/details/location-selector/index.tsx
@@ -42,7 +42,7 @@ type LocationSelectorProps = {
 const LocationSelector: React.FC<LocationSelectorProps> = ({ className }) => {
   const {
     push,
-    query: { locationCode },
+    query: { locationCode = 'GLOB' },
   } = useRouter();
 
   // @ts-expect-error to work properly, strict mode should be enabled

--- a/frontend/src/containers/map/sidebar/main-panel/details/location-selector/location-dropdown/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/details/location-selector/location-dropdown/index.tsx
@@ -27,7 +27,7 @@ const LocationDropdown: React.FC<LocationDropdownProps> = ({
   onSelected,
 }) => {
   const {
-    query: { locationCode },
+    query: { locationCode = 'GLOB' },
   } = useRouter();
 
   const locationsQuery = useGetLocations(

--- a/frontend/src/containers/map/sidebar/main-panel/details/widgets/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/details/widgets/index.tsx
@@ -5,14 +5,14 @@ import { cn } from '@/lib/classnames';
 import { useGetLocations } from '@/types/generated/location';
 
 // import EstablishmentStagesWidget from './establishment-stages';
+import FishingProtectionWidget from './fishing-protection';
 import HabitatWidget from './habitat';
 import MarineConservationWidget from './marine-conservation';
 import ProtectionTypesWidget from './protection-types';
-import FishingProtectionWidget from './fishing-protection';
 
 const DetailsWidgets: React.FC = () => {
   const {
-    query: { locationCode },
+    query: { locationCode = 'GLOB' },
   } = useRouter();
 
   const [{ showDetails }] = useSyncMapContentSettings();

--- a/frontend/src/containers/map/sidebar/main-panel/modelling/widget/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/modelling/widget/index.tsx
@@ -2,14 +2,14 @@ import { PropsWithChildren, useMemo } from 'react';
 
 import { useAtomValue } from 'jotai';
 
-import useTooltips from '../useTooltips';
-
 import HorizontalBarChart from '@/components/charts/horizontal-bar-chart';
 import TooltipButton from '@/components/tooltip-button';
 import Widget from '@/components/widget';
 import { modellingAtom } from '@/containers/map/store';
 import { cn } from '@/lib/classnames';
 import { useGetLocations } from '@/types/generated/location';
+
+import useTooltips from '../useTooltips';
 
 const DEFAULT_ENTRY_CLASSNAMES = 'border-t border-black py-6';
 

--- a/frontend/src/pages/progress-tracker/[locationCode].tsx
+++ b/frontend/src/pages/progress-tracker/[locationCode].tsx
@@ -4,10 +4,10 @@ import type { GetServerSideProps } from 'next';
 import MapLayout from '@/layouts/map';
 import { getGetLocationsQueryKey, getGetLocationsQueryOptions } from '@/types/generated/location';
 import { LocationListResponse } from '@/types/generated/strapi.schemas';
-
+// DEBUG
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const { query } = context;
-  const { locationCode } = query;
+  const { locationCode = 'GLOB' } = query;
 
   const queryClient = new QueryClient();
 


### PR DESCRIPTION
### Overview

This PR defaults the `locationCode` to `GLOB` when using `useRouter` or `useParams` throughout the app. This was the (working) solution implemented to solve some of the bugs. 

I think there has to be a better way though. 

**Note:** there are some extra changes due to linting errors I saw. 

### Testing  

The bug doesn't seem to exhibit locally; in order to reproduce it locally I had to run a production build. 

### Feature relevant tickets

[https://vizzuality.atlassian.net/browse/SKY30-350](https://vizzuality.atlassian.net/browse/SKY30-350)