### PR TITLE
[SKY30-305/SKY30-341SKY30-353]widget redesign and sources implementation

### DIFF
--- a/frontend/src/components/charts/horizontal-bar-chart/index.tsx
+++ b/frontend/src/components/charts/horizontal-bar-chart/index.tsx
@@ -15,6 +15,15 @@ type HorizontalBarChartProps = {
     totalArea: number;
     protectedArea: number;
     info?: string;
+    sources?:
+      | {
+          title: string;
+          url: string;
+        }
+      | {
+          title: string;
+          url: string;
+        }[];
   };
   showLegend?: boolean;
   showTarget?: boolean;
@@ -26,7 +35,7 @@ const HorizontalBarChart: React.FC<HorizontalBarChartProps> = ({
   showLegend = true,
   showTarget = true,
 }) => {
-  const { title, background, totalArea, protectedArea, info } = data;
+  const { title, background, totalArea, protectedArea, info, sources } = data;
 
   const targetPositionPercentage = useMemo(() => {
     return (PROTECTION_TARGET * 100) / DEFAULT_MAX_PERCENTAGE;
@@ -44,26 +53,25 @@ const HorizontalBarChart: React.FC<HorizontalBarChartProps> = ({
     return relativeToMaxPercentage > DEFAULT_MAX_PERCENTAGE ? 100 : relativeToMaxPercentage;
   }, [protectedArea, totalArea]);
 
-  const formattedArea = useMemo(() => {
-    return formatKM(totalArea);
-  }, [totalArea]);
-
   return (
     <div className={cn('font-mono', className)}>
-      <div className="flex items-end justify-end text-3xl font-bold">
-        {protectedAreaPercentage}
-        <span className="pb-1.5 pl-1 text-xs">%</span>
+      <div className="space-y-2">
+        <div className="flex justify-between text-xs">
+          {title && <h3 className="font-sans text-base font-bold">{title}</h3>}
+          {info && <TooltipButton text={info} sources={sources} />}
+        </div>
+        <div className="text-4xl font-bold">
+          {protectedAreaPercentage}
+          <span className="pb-1.5 pl-1 text-xs">%</span>
+        </div>
       </div>
-      <div className="flex justify-between text-xs">
-        <span className="flex items-center">
-          {title && title}
-          {info && <TooltipButton text={info} />}
-        </span>
-        <span>
-          out of {formattedArea} km<sup>2</sup>
-        </span>
-      </div>
-      <div className="relative my-2 flex h-3.5">
+      <span className="text-xs">
+        {formatKM(protectedArea)} km<sup>2</sup>
+      </span>{' '}
+      <span className="text-xs">
+        out of {formatKM(totalArea)} km<sup>2</sup>
+      </span>
+      <div className="relative mb-2 flex h-3.5">
         <span className="absolute top-1/2 h-px w-full border-b border-dashed border-black"></span>
         <span
           className="absolute top-0 bottom-0 left-0 border border-black !bg-cover"

--- a/frontend/src/components/tooltip-button/index.tsx
+++ b/frontend/src/components/tooltip-button/index.tsx
@@ -11,17 +11,28 @@ import { cn } from '@/lib/classnames';
 type TooltipButtonProps = {
   className?: string;
   text: string;
+  sources?:
+    | {
+        title: string;
+        url: string;
+      }
+    | {
+        title: string;
+        url: string;
+      }[];
 };
 
-const TooltipButton: React.FC<TooltipButtonProps> = ({ className, text }) => {
+const TooltipButton: React.FC<TooltipButtonProps> = ({ className, text, sources }) => {
   const [isTooltipOpen, setIsTooltipOpen] = useState<boolean>(false);
-
-  if (!text) return null;
 
   return (
     <Popover open={isTooltipOpen} onOpenChange={setIsTooltipOpen}>
       <PopoverTrigger asChild>
-        <Button className={cn('h-auto w-auto pl-1.5', className)} size="icon" variant="ghost">
+        <Button
+          className={cn('h-auto w-auto pl-1.5 hover:bg-transparent', className)}
+          size="icon"
+          variant="ghost"
+        >
           <span className="sr-only">Info</span>
           <Info className="h-4 w-4" aria-hidden="true" />
         </Button>
@@ -30,23 +41,55 @@ const TooltipButton: React.FC<TooltipButtonProps> = ({ className, text }) => {
         align="center"
         className="flex max-w-[300px] flex-col gap-6 font-mono text-xs"
       >
-        <span>
-          <Linkify
-            componentDecorator={(href, text, key) => (
-              <a
-                className="break-all underline"
-                href={href}
-                key={key}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {text}
-              </a>
-            )}
+        {text && (
+          <span>
+            <Linkify
+              componentDecorator={(href, text, key) => (
+                <a
+                  className="break-all underline"
+                  href={href}
+                  key={key}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {text}
+                </a>
+              )}
+            >
+              {text}
+            </Linkify>
+          </span>
+        )}
+
+        {Array.isArray(sources) && (
+          <div className="">
+            <span>Data sources: </span>
+            {sources.map(({ title, url }, index) => (
+              <>
+                <a
+                  key={title}
+                  href={url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-semibold underline"
+                >
+                  {title}
+                </a>
+                {index < sources.length - 1 && <span>, </span>}
+              </>
+            ))}
+          </div>
+        )}
+        {sources && !Array.isArray(sources) && (
+          <a
+            href={sources?.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-semibold underline"
           >
-            {text}
-          </Linkify>
-        </span>
+            Data source
+          </a>
+        )}
       </PopoverContent>
     </Popover>
   );

--- a/frontend/src/components/widget/index.tsx
+++ b/frontend/src/components/widget/index.tsx
@@ -12,23 +12,25 @@ import NoData from './no-data';
 type WidgetProps = {
   className?: string;
   title?: string;
-  tooltip?: string;
   lastUpdated?: string;
   noData?: boolean;
   loading?: boolean;
   error?: boolean;
   messageError?: ComponentProps<typeof NoData>['message'];
+  info?: ComponentProps<typeof TooltipButton>['text'];
+  sources?: ComponentProps<typeof TooltipButton>['sources'];
 };
 
 const Widget: React.FC<PropsWithChildren<WidgetProps>> = ({
   className,
   title,
   lastUpdated,
-  tooltip,
   noData = false,
   loading = false,
   error = false,
   messageError = undefined,
+  info,
+  sources,
   children,
 }) => {
   const formattedLastUpdated = useMemo(
@@ -41,12 +43,12 @@ const Widget: React.FC<PropsWithChildren<WidgetProps>> = ({
   return (
     <div className={cn('py-4 px-4 md:px-8', className)}>
       <div className="pt-2">
-        <span className="flex">
-          {title && <h2 className="font-sans text-xl font-bold">{title}</h2>}
-          {tooltip && <TooltipButton text={tooltip} className="mt-1 hover:bg-transparent" />}
+        <span className="flex items-baseline justify-between">
+          {title && <h2 className="font-sans text-xl font-bold leading-tight">{title}</h2>}
+          {(info || sources) && <TooltipButton text={info} sources={sources} />}
         </span>
         {!showNoData && lastUpdated && (
-          <span className="text-xs">Data last updated: {formattedLastUpdated}</span>
+          <span className="text-xs">Updated on {formattedLastUpdated}</span>
         )}
       </div>
       {loading && <Loading />}

--- a/frontend/src/containers/map/sidebar/main-panel/details/widgets/establishment-stages/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/details/widgets/establishment-stages/index.tsx
@@ -7,8 +7,6 @@ import Widget from '@/components/widget';
 import { useGetMpaaEstablishmentStageStats } from '@/types/generated/mpaa-establishment-stage-stat';
 import type { LocationGroupsDataItemAttributes } from '@/types/generated/strapi.schemas';
 
-import useTooltips from '../useTooltips';
-
 type EstablishmentStagesWidgetProps = {
   location: LocationGroupsDataItemAttributes;
 };
@@ -66,8 +64,6 @@ const EstablishmentStagesWidget: React.FC<EstablishmentStagesWidgetProps> = ({ l
     }
   );
 
-  const tooltips = useTooltips();
-
   // Merge OECM and MPA stats
   const mergedEstablishmentStagesStats = useMemo(() => {
     if (!establishmentStagesData.length) return [];
@@ -117,7 +113,6 @@ const EstablishmentStagesWidget: React.FC<EstablishmentStagesWidgetProps> = ({ l
   return (
     <Widget
       title="Marine Conservation Establishment Stages"
-      tooltip={tooltips?.['establishmentStages']}
       lastUpdated={dataLastUpdate}
       noData={noData}
       loading={loading}

--- a/frontend/src/containers/map/sidebar/main-panel/details/widgets/fishing-protection/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/details/widgets/fishing-protection/index.tsx
@@ -3,10 +3,9 @@ import { useMemo } from 'react';
 import HorizontalBarChart from '@/components/charts/horizontal-bar-chart';
 import Widget from '@/components/widget';
 import { FISHING_PROTECTION_CHART_COLORS } from '@/constants/fishing-protection-chart-colors';
+import { useGetDataInfos } from '@/types/generated/data-info';
 import { useGetLocations } from '@/types/generated/location';
 import type { LocationGroupsDataItemAttributes } from '@/types/generated/strapi.schemas';
-
-import useTooltips from '../useTooltips';
 
 type ProtectionTypesWidgetProps = {
   location: LocationGroupsDataItemAttributes;
@@ -48,7 +47,55 @@ const ProtectionTypesWidget: React.FC<ProtectionTypesWidgetProps> = ({ location 
     }
   );
 
-  const tooltips = useTooltips();
+  const { data: metadataWidget } = useGetDataInfos(
+    {
+      filters: {
+        slug: 'fishing-protection-widget',
+      },
+      populate: 'data_sources',
+    },
+    {
+      query: {
+        select: ({ data }) =>
+          data[0]
+            ? {
+                info: data[0].attributes.content,
+                sources: data[0].attributes?.data_sources?.data?.map(
+                  ({ attributes: { title, url } }) => ({
+                    title,
+                    url,
+                  })
+                ),
+              }
+            : undefined,
+      },
+    }
+  );
+
+  const { data: metadata } = useGetDataInfos(
+    {
+      filters: {
+        slug: 'fishing-protection-level',
+      },
+      populate: 'data_sources',
+    },
+    {
+      query: {
+        select: ({ data }) =>
+          data[0]
+            ? {
+                info: data[0]?.attributes?.content,
+                sources: data[0]?.attributes?.data_sources?.data?.map(
+                  ({ attributes: { title, url } }) => ({
+                    title,
+                    url,
+                  })
+                ),
+              }
+            : undefined,
+      },
+    }
+  );
 
   // Parse data to display in the chart
   const widgetChartData = useMemo(() => {
@@ -61,7 +108,8 @@ const ProtectionTypesWidget: React.FC<ProtectionTypesWidgetProps> = ({ location 
         background: FISHING_PROTECTION_CHART_COLORS[protectionLevel.slug],
         totalArea: location.totalMarineArea,
         protectedArea: stats?.area,
-        info: protectionLevel.info,
+        info: metadata?.info,
+        sources: metadata?.sources,
       };
     };
 
@@ -73,7 +121,7 @@ const ProtectionTypesWidget: React.FC<ProtectionTypesWidgetProps> = ({ location 
       });
 
     return parsedFishingProtectionLevelData;
-  }, [location, protectionLevelsData]);
+  }, [location, protectionLevelsData, metadata]);
 
   const noData = !widgetChartData.length;
 
@@ -82,10 +130,11 @@ const ProtectionTypesWidget: React.FC<ProtectionTypesWidgetProps> = ({ location 
   return (
     <Widget
       title="Fishing Protection"
-      tooltip={tooltips?.['fishingProtection']}
       lastUpdated={protectionLevelsData[0]?.attributes?.updatedAt}
       noData={noData}
       loading={loading}
+      info={metadataWidget?.info}
+      sources={metadataWidget?.sources}
     >
       {widgetChartData.map((chartData) => (
         <HorizontalBarChart key={chartData.slug} className="py-2" data={chartData} />

--- a/frontend/src/containers/map/sidebar/main-panel/details/widgets/habitat/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/details/widgets/habitat/index.tsx
@@ -54,30 +54,30 @@ const HabitatWidget: React.FC<HabitatWidgetProps> = ({ location }) => {
     }
   );
 
-  const { data: metadataWidget } = useGetDataInfos(
-    {
-      filters: {
-        slug: 'habitats-widget',
-      },
-      populate: 'data_sources',
-    },
-    {
-      query: {
-        select: ({ data }) =>
-          data[0]
-            ? {
-                info: data[0].attributes.content,
-                sources: data[0].attributes?.data_sources?.data?.map(
-                  ({ attributes: { title, url } }) => ({
-                    title,
-                    url,
-                  })
-                ),
-              }
-            : undefined,
-      },
-    }
-  );
+  // const { data: metadataWidget } = useGetDataInfos(
+  //   {
+  //     filters: {
+  //       slug: 'habitats-widget',
+  //     },
+  //     populate: 'data_sources',
+  //   },
+  //   {
+  //     query: {
+  //       select: ({ data }) =>
+  //         data[0]
+  //           ? {
+  //               info: data[0].attributes.content,
+  //               sources: data[0].attributes?.data_sources?.data?.map(
+  //                 ({ attributes: { title, url } }) => ({
+  //                   title,
+  //                   url,
+  //                 })
+  //               ),
+  //             }
+  //           : undefined,
+  //     },
+  //   }
+  // );
 
   const { data: habitatMetadatas } = useGetDataInfos(
     {
@@ -145,8 +145,8 @@ const HabitatWidget: React.FC<HabitatWidgetProps> = ({ location }) => {
       lastUpdated={dataLastUpdate}
       noData={noData}
       loading={loading}
-      info={metadataWidget?.info}
-      sources={metadataWidget?.sources}
+      // info={metadataWidget?.info}
+      // sources={metadataWidget?.sources}
     >
       {widgetChartData.map((chartData) => (
         <HorizontalBarChart

--- a/frontend/src/containers/map/sidebar/main-panel/details/widgets/habitat/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/details/widgets/habitat/index.tsx
@@ -3,10 +3,9 @@ import { useMemo } from 'react';
 import HorizontalBarChart from '@/components/charts/horizontal-bar-chart';
 import Widget from '@/components/widget';
 import { HABITAT_CHART_COLORS } from '@/constants/habitat-chart-colors';
+import { useGetDataInfos } from '@/types/generated/data-info';
 import { useGetHabitatStats } from '@/types/generated/habitat-stat';
 import type { LocationGroupsDataItemAttributes } from '@/types/generated/strapi.schemas';
-
-import useTooltips from '../useTooltips';
 
 type HabitatWidgetProps = {
   location: LocationGroupsDataItemAttributes;
@@ -55,7 +54,64 @@ const HabitatWidget: React.FC<HabitatWidgetProps> = ({ location }) => {
     }
   );
 
-  const tooltips = useTooltips();
+  const { data: metadataWidget } = useGetDataInfos(
+    {
+      filters: {
+        slug: 'habitats-widget',
+      },
+      populate: 'data_sources',
+    },
+    {
+      query: {
+        select: ({ data }) =>
+          data[0]
+            ? {
+                info: data[0].attributes.content,
+                sources: data[0].attributes?.data_sources?.data?.map(
+                  ({ attributes: { title, url } }) => ({
+                    title,
+                    url,
+                  })
+                ),
+              }
+            : undefined,
+      },
+    }
+  );
+
+  const { data: habitatMetadatas } = useGetDataInfos(
+    {
+      filters: {
+        slug: [
+          'cold-water corals',
+          'warm-water corals',
+          'mangroves',
+          'seagrasses',
+          'saltmarshes',
+          'mangroves',
+          'seamounts',
+        ],
+      },
+      populate: 'data_sources',
+    },
+    {
+      query: {
+        select: ({ data }) =>
+          data
+            ? data.map((item) => ({
+                slug: item.attributes.slug,
+                info: item.attributes.content,
+                sources: item.attributes?.data_sources?.data?.map(
+                  ({ attributes: { title, url } }) => ({
+                    title,
+                    url,
+                  })
+                ),
+              }))
+            : undefined,
+      },
+    }
+  );
 
   const widgetChartData = useMemo(() => {
     if (!habitatStatsData) return [];
@@ -64,17 +120,21 @@ const HabitatWidget: React.FC<HabitatWidgetProps> = ({ location }) => {
       const stats = entry?.attributes;
       const habitat = stats?.habitat?.data.attributes;
 
+      const metadata = habitatMetadatas?.find(({ slug }) => slug === habitat.slug);
+
       return {
         title: habitat.name,
         slug: habitat.slug,
         background: HABITAT_CHART_COLORS[habitat.slug],
         totalArea: stats.totalArea,
         protectedArea: stats.protectedArea,
+        info: metadata?.info,
+        sources: metadata?.sources,
       };
     });
 
     return parsedData.reverse();
-  }, [habitatStatsData]);
+  }, [habitatStatsData, habitatMetadatas]);
 
   const noData = !widgetChartData.length;
   const loading = isFetchingHabitatStatsData || isFetchingDataLastUpdate;
@@ -82,10 +142,11 @@ const HabitatWidget: React.FC<HabitatWidgetProps> = ({ location }) => {
   return (
     <Widget
       title="Proportion of Habitat within Protected and Conserved Areas"
-      tooltip={tooltips?.['habitats']}
       lastUpdated={dataLastUpdate}
       noData={noData}
       loading={loading}
+      info={metadataWidget?.info}
+      sources={metadataWidget?.sources}
     >
       {widgetChartData.map((chartData) => (
         <HorizontalBarChart

--- a/frontend/src/containers/map/sidebar/main-panel/details/widgets/marine-conservation/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/details/widgets/marine-conservation/index.tsx
@@ -6,6 +6,7 @@ import ConservationChart from '@/components/charts/conservation-chart';
 import Widget from '@/components/widget';
 import { formatKM } from '@/lib/utils/formats';
 import { formatPercentage } from '@/lib/utils/formats';
+import { useGetDataInfos } from '@/types/generated/data-info';
 import { useGetProtectionCoverageStats } from '@/types/generated/protection-coverage-stat';
 import type { LocationGroupsDataItemAttributes } from '@/types/generated/strapi.schemas';
 
@@ -82,6 +83,31 @@ const MarineConservationWidget: React.FC<MarineConservationWidgetProps> = ({ loc
     });
   }, [protectionStatsData]);
 
+  const { data: metadata } = useGetDataInfos(
+    {
+      filters: {
+        slug: 'coverage-widget',
+      },
+      populate: 'data_sources',
+    },
+    {
+      query: {
+        select: ({ data }) =>
+          data[0]
+            ? {
+                info: data[0].attributes.content,
+                sources: data[0].attributes?.data_sources?.data?.map(
+                  ({ attributes: { title, url } }) => ({
+                    title,
+                    url,
+                  })
+                ),
+              }
+            : undefined,
+      },
+    }
+  );
+
   const stats = useMemo(() => {
     if (!mergedProtectionStats) return null;
 
@@ -135,6 +161,8 @@ const MarineConservationWidget: React.FC<MarineConservationWidgetProps> = ({ loc
       lastUpdated={dataLastUpdate}
       noData={noData}
       loading={loading}
+      info={metadata?.info}
+      sources={metadata?.sources}
     >
       {stats && (
         <div className="mt-6 mb-4 flex flex-col">

--- a/frontend/src/containers/map/sidebar/main-panel/details/widgets/marine-conservation/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/details/widgets/marine-conservation/index.tsx
@@ -10,8 +10,6 @@ import { useGetDataInfos } from '@/types/generated/data-info';
 import { useGetProtectionCoverageStats } from '@/types/generated/protection-coverage-stat';
 import type { LocationGroupsDataItemAttributes } from '@/types/generated/strapi.schemas';
 
-import useTooltips from '../useTooltips';
-
 type MarineConservationWidgetProps = {
   location: LocationGroupsDataItemAttributes;
 };
@@ -61,8 +59,6 @@ const MarineConservationWidget: React.FC<MarineConservationWidgetProps> = ({ loc
       },
     }
   );
-
-  const tooltips = useTooltips();
 
   const mergedProtectionStats = useMemo(() => {
     if (!protectionStatsData.length) return null;
@@ -157,7 +153,6 @@ const MarineConservationWidget: React.FC<MarineConservationWidgetProps> = ({ loc
   return (
     <Widget
       title="Marine Conservation Coverage"
-      tooltip={tooltips?.['marineConservation']}
       lastUpdated={dataLastUpdate}
       noData={noData}
       loading={loading}

--- a/frontend/src/containers/map/sidebar/main-panel/details/widgets/protection-types/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/details/widgets/protection-types/index.tsx
@@ -47,30 +47,30 @@ const ProtectionTypesWidget: React.FC<ProtectionTypesWidgetProps> = ({ location 
     }
   );
 
-  const { data: metadataWidget } = useGetDataInfos(
-    {
-      filters: {
-        slug: 'protection-levels-widget',
-      },
-      populate: 'data_sources',
-    },
-    {
-      query: {
-        select: ({ data }) =>
-          data[0]
-            ? {
-                info: data[0].attributes.content,
-                sources: data[0].attributes?.data_sources?.data?.map(
-                  ({ attributes: { title, url } }) => ({
-                    title,
-                    url,
-                  })
-                ),
-              }
-            : undefined,
-      },
-    }
-  );
+  // const { data: metadataWidget } = useGetDataInfos(
+  //   {
+  //     filters: {
+  //       slug: 'protection-levels-widget',
+  //     },
+  //     populate: 'data_sources',
+  //   },
+  //   {
+  //     query: {
+  //       select: ({ data }) =>
+  //         data[0]
+  //           ? {
+  //               info: data[0].attributes.content,
+  //               sources: data[0].attributes?.data_sources?.data?.map(
+  //                 ({ attributes: { title, url } }) => ({
+  //                   title,
+  //                   url,
+  //                 })
+  //               ),
+  //             }
+  //           : undefined,
+  //     },
+  //   }
+  // );
 
   const { data: metadata } = useGetDataInfos(
     {
@@ -133,8 +133,8 @@ const ProtectionTypesWidget: React.FC<ProtectionTypesWidgetProps> = ({ location 
       lastUpdated={protectionLevelsData[0]?.attributes?.updatedAt}
       noData={noData}
       loading={loading}
-      info={metadataWidget?.info}
-      sources={metadataWidget?.sources}
+      // info={metadataWidget?.info}
+      // sources={metadataWidget?.sources}
     >
       {widgetChartData.map((chartData) => (
         <HorizontalBarChart key={chartData.slug} className="py-2" data={chartData} />

--- a/frontend/src/containers/map/sidebar/main-panel/details/widgets/protection-types/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/details/widgets/protection-types/index.tsx
@@ -3,10 +3,9 @@ import { useMemo } from 'react';
 import HorizontalBarChart from '@/components/charts/horizontal-bar-chart';
 import Widget from '@/components/widget';
 import { PROTECTION_TYPES_CHART_COLORS } from '@/constants/protection-types-chart-colors';
+import { useGetDataInfos } from '@/types/generated/data-info';
 import { useGetLocations } from '@/types/generated/location';
 import type { LocationGroupsDataItemAttributes } from '@/types/generated/strapi.schemas';
-
-import useTooltips from '../useTooltips';
 
 type ProtectionTypesWidgetProps = {
   location: LocationGroupsDataItemAttributes;
@@ -48,7 +47,55 @@ const ProtectionTypesWidget: React.FC<ProtectionTypesWidgetProps> = ({ location 
     }
   );
 
-  const tooltips = useTooltips();
+  const { data: metadataWidget } = useGetDataInfos(
+    {
+      filters: {
+        slug: 'protection-types-widget',
+      },
+      populate: 'data_sources',
+    },
+    {
+      query: {
+        select: ({ data }) =>
+          data[0]
+            ? {
+                info: data[0].attributes.content,
+                sources: data[0].attributes?.data_sources?.data?.map(
+                  ({ attributes: { title, url } }) => ({
+                    title,
+                    url,
+                  })
+                ),
+              }
+            : undefined,
+      },
+    }
+  );
+
+  const { data: metadata } = useGetDataInfos(
+    {
+      filters: {
+        slug: 'fully-highly-protected',
+      },
+      populate: 'data_sources',
+    },
+    {
+      query: {
+        select: ({ data }) =>
+          data[0]
+            ? {
+                info: data[0]?.attributes?.content,
+                sources: data[0]?.attributes?.data_sources?.data?.map(
+                  ({ attributes: { title, url } }) => ({
+                    title,
+                    url,
+                  })
+                ),
+              }
+            : undefined,
+      },
+    }
+  );
 
   // Parse data to display in the chart
   const widgetChartData = useMemo(() => {
@@ -61,7 +108,8 @@ const ProtectionTypesWidget: React.FC<ProtectionTypesWidgetProps> = ({ location 
         background: PROTECTION_TYPES_CHART_COLORS[protectionLevel.slug],
         totalArea: location.totalMarineArea,
         protectedArea: stats?.area,
-        info: protectionLevel.info,
+        info: metadata?.info,
+        sources: metadata?.sources,
       };
     };
 
@@ -73,7 +121,7 @@ const ProtectionTypesWidget: React.FC<ProtectionTypesWidgetProps> = ({ location 
       });
 
     return parsedMpaaProtectionLevelData;
-  }, [location, protectionLevelsData]);
+  }, [location, protectionLevelsData, metadata]);
 
   const noData = !widgetChartData.length;
 
@@ -82,10 +130,11 @@ const ProtectionTypesWidget: React.FC<ProtectionTypesWidgetProps> = ({ location 
   return (
     <Widget
       title="Marine Conservation Protection Levels"
-      tooltip={tooltips?.['protectionTypes']}
       lastUpdated={protectionLevelsData[0]?.attributes?.updatedAt}
       noData={noData}
       loading={loading}
+      info={metadataWidget?.info}
+      sources={metadataWidget?.sources}
     >
       {widgetChartData.map((chartData) => (
         <HorizontalBarChart key={chartData.slug} className="py-2" data={chartData} />

--- a/frontend/src/containers/map/sidebar/main-panel/details/widgets/protection-types/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/details/widgets/protection-types/index.tsx
@@ -50,7 +50,7 @@ const ProtectionTypesWidget: React.FC<ProtectionTypesWidgetProps> = ({ location 
   const { data: metadataWidget } = useGetDataInfos(
     {
       filters: {
-        slug: 'protection-types-widget',
+        slug: 'protection-levels-widget',
       },
       populate: 'data_sources',
     },


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

![image](https://github.com/Vizzuality/skytruth-30x30/assets/999124/b618ffc2-e24e-4704-9079-7b038eb23b3e)
![image](https://github.com/Vizzuality/skytruth-30x30/assets/999124/42d800be-c514-489d-b050-bb8ab9f472a1)

- Redesigns a little the distribution of elements inside the widgets.
- Adds total area to widgets along with the current protected area.
- Adds sources inside tooltip buttons.


### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/SKY30-305
https://vizzuality.atlassian.net/browse/SKY30-341
https://vizzuality.atlassian.net/browse/SKY30-353

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.