### PR TITLE
[SKY30-333] adds total area to EEZ and Regions popups

### DIFF
--- a/frontend/src/containers/map/content/map/popup/eez/index.tsx
+++ b/frontend/src/containers/map/content/map/popup/eez/index.tsx
@@ -190,15 +190,16 @@ const EEZLayerPopup = ({ locationId }) => {
         <>
           <div className="space-y-2">
             <div className="my-4 max-w-[95%] font-mono">Marine Conservation Coverage</div>
-            <div className="space-x-1 font-mono tracking-tighter text-blue">
+            <div className="space-x-1 font-mono tracking-tighter text-black">
               <span className="text-[64px] font-bold leading-[80%]">{coveragePercentage}</span>
               {coveragePercentage !== '-' && <span className="text-lg">%</span>}
             </div>
-            <div className="space-x-1 font-mono text-xl text-blue">
+            <div className="space-x-1 font-mono text-xs font-medium text-black">
               <span>{formatKM(totalCumSumProtectedArea)}</span>
               <span>
                 km<sup>2</sup>
-              </span>
+              </span>{' '}
+              out of {formatKM(locationsQuery.data.totalMarineArea)} km<sup>2</sup>
             </div>
           </div>
           <button

--- a/frontend/src/containers/map/content/map/popup/regions/index.tsx
+++ b/frontend/src/containers/map/content/map/popup/regions/index.tsx
@@ -197,17 +197,18 @@ const EEZLayerPopup = ({ locationId }) => {
         <>
           <div className="space-y-2">
             <div className="my-4 max-w-[95%] font-mono">Marine Conservation Coverage</div>
-            <div className="space-x-1 font-mono tracking-tighter text-blue">
+            <div className="space-x-1 font-mono tracking-tighter text-black">
               <span className="text-[64px] font-bold leading-[80%]">
                 {coverageStats.percentage}
               </span>
               {coverageStats.percentage !== '-' && <span className="text-lg">%</span>}
             </div>
-            <div className="space-x-1 font-mono text-xl text-blue">
+            <div className="space-x-1 font-mono font-medium text-black">
               <span>{coverageStats.protectedArea}</span>
               <span>
                 km<sup>2</sup>
-              </span>
+              </span>{' '}
+              out of {formatKM(locationsQuery.data.totalMarineArea)} km<sup>2</sup>
             </div>
           </div>
           <button


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

![image](https://github.com/Vizzuality/skytruth-30x30/assets/999124/35d0d8b3-21ac-475e-83f6-d49c0b6dfdfe)
![image](https://github.com/Vizzuality/skytruth-30x30/assets/999124/89590c42-ad3c-488f-aeb7-a2db50c059b7)

Adds total area to EEZ and Regions popups. Also, updates color from blue to black according to design.

### Designs

https://www.figma.com/file/RQB86KnkGg4UTpqQZ09KBX/30x30-Design-%5BInternal%5D?node-id=2371%3A13002&mode=dev

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/SKY30-333

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.