### PR TITLE
[SKY30-318] Update default sort of tables to be alphabetical

### DIFF
--- a/frontend/src/containers/map/content/details/table/index.tsx
+++ b/frontend/src/containers/map/content/details/table/index.tsx
@@ -17,6 +17,14 @@ const MapTable = ({ columns, data }) => {
   const table = useReactTable<typeof data>({
     data,
     columns,
+    initialState: {
+      sorting: [
+        {
+          id: columns?.[0]?.accessorKey,
+          desc: false,
+        },
+      ],
+    },
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
   });

--- a/frontend/src/containers/map/content/details/table/sorting-button/index.tsx
+++ b/frontend/src/containers/map/content/details/table/sorting-button/index.tsx
@@ -38,7 +38,7 @@ const SortingButton: React.FC<SortingButtonProps> = ({ column }) => {
           onClick={() => column.toggleSorting(true)}
         >
           <span className="sr-only">Sort descending</span>
-          <ArrowDownNarrowWide className={ICON_CLASSNAMES} aria-hidden />
+          <ArrowUpNarrowWide className={ICON_CLASSNAMES} aria-hidden />
         </Button>
       )}
       {isSorted === 'desc' && (
@@ -49,7 +49,7 @@ const SortingButton: React.FC<SortingButtonProps> = ({ column }) => {
           onClick={() => column.clearSorting()}
         >
           <span className="sr-only">Clear sorting</span>
-          <ArrowUpNarrowWide className={ICON_CLASSNAMES} aria-hidden />
+          <ArrowDownNarrowWide className={ICON_CLASSNAMES} aria-hidden />
         </Button>
       )}
     </>


### PR DESCRIPTION
### Overview

This PR sets the default sorting on tables so that the first column is ordered alphabetically (in ascending order) by default. 
It also fixes the asc/desc icons being flipped. 

### Feature relevant tickets

[SKY30-318](https://vizzuality.atlassian.net/browse/SKY30-318)

[SKY30-318]: https://vizzuality.atlassian.net/browse/SKY30-318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ