### PR TITLE
[SKY30-361] Safari: fixes menu item break into two rows

### DIFF
--- a/frontend/src/components/header.tsx
+++ b/frontend/src/components/header.tsx
@@ -124,7 +124,7 @@ const Header: React.FC<HeaderProps> = ({ theme, hideLogo = false }) => (
           <li key={href}>
             <ActiveLink
               href={href}
-              className="group -mx-3 block px-3 py-2 ring-offset-white transition-colors hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black focus-visible:ring-offset-2"
+              className="group -mx-3 flex px-3 py-2 ring-offset-white transition-colors hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black focus-visible:ring-offset-2"
               activeClassName="bg-white text-black hover:bg-white is-active"
             >
               <Icon


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

Fixes _Progress tracker_ item broken in Safari

![image](https://github.com/Vizzuality/skytruth-30x30/assets/999124/1541c863-b060-426d-98fe-3b4c6766569b)


### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/SKY30-361

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.