### PR TITLE
[SKY30-362]: hides internal protection levels & fixes select all filtering

### DIFF
--- a/frontend/src/containers/map/content/details/tables/national-highseas/index.tsx
+++ b/frontend/src/containers/map/content/details/tables/national-highseas/index.tsx
@@ -104,7 +104,7 @@ const NationalHighseasTable: React.FC = () => {
         coverage: coveragePercentage,
         protectedAreaType: protectionStatus?.slug,
         establishmentStage: establishmentStage?.slug,
-        protectionLevel: mpaaProtectionLevel?.slug,
+        protectionLevel: mpaaProtectionLevel?.slug || 'unknown',
         fishingProtectionLevel: fishingProtectionLevel?.slug,
         area: mpa?.area,
       };

--- a/frontend/src/containers/map/content/details/tables/national-highseas/useFiltersOptions.ts
+++ b/frontend/src/containers/map/content/details/tables/national-highseas/useFiltersOptions.ts
@@ -47,7 +47,12 @@ const useFiltersOptions = () => {
     {},
     {
       query: {
-        select: ({ data }) => data,
+        select: ({ data }) =>
+          data.filter(
+            ({ attributes }) =>
+              // ? these protection values are used internally, but they should not be visible to the user
+              !['fully-highly-protected', 'less-protected-unknown'].includes(attributes?.slug)
+          ),
         placeholderData: { data: [] },
       },
     }
@@ -66,13 +71,12 @@ const useFiltersOptions = () => {
     {
       query: {
         select: ({ data }) => data,
-        placeholderData: { data: [] },
       },
     }
   );
 
   const fishingProtectionLevelOptions = useMemo(() => {
-    return fishingProtectionLevels.map(({ attributes }) => ({
+    return fishingProtectionLevels?.map(({ attributes }) => ({
       name: attributes?.name,
       value: attributes?.slug,
     }));


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

![image](https://github.com/Vizzuality/skytruth-30x30/assets/999124/2896375f-411a-4b64-b8b6-3f2ea5f6f57f)

Also, fixes filtering when the user _selects all_


### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/SKY30-362

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.