### PR TITLE
[SKY30-365]: hides show target label in marine conservation widget

### DIFF
--- a/frontend/src/containers/map/sidebar/main-panel/details/widgets/protection-types/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/details/widgets/protection-types/index.tsx
@@ -137,7 +137,12 @@ const ProtectionTypesWidget: React.FC<ProtectionTypesWidgetProps> = ({ location 
       // sources={metadataWidget?.sources}
     >
       {widgetChartData.map((chartData) => (
-        <HorizontalBarChart key={chartData.slug} className="py-2" data={chartData} />
+        <HorizontalBarChart
+          key={chartData.slug}
+          showTarget={false}
+          className="py-2"
+          data={chartData}
+        />
       ))}
     </Widget>
   );


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

![image](https://github.com/Vizzuality/skytruth-30x30/assets/999124/e38f7bfe-de0b-4f80-865f-04a8347e1e5e)


Hides _target 30x30_ label in Marine Conservation Protection Levels widget.

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/SKY30-365

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.