### PR TITLE
[SKY30-358] Map to respond to location changes and update bbox accordingly

### DIFF
--- a/frontend/src/containers/map/content/map/index.tsx
+++ b/frontend/src/containers/map/content/map/index.tsx
@@ -10,6 +10,7 @@ import { useResetAtom } from 'jotai/utils';
 
 import Map, { ZoomControls, Attributions } from '@/components/map';
 import { DEFAULT_VIEW_STATE } from '@/components/map/constants';
+import { CustomMapProps } from '@/components/map/types';
 import DrawControls from '@/containers/map/content/map/draw-controls';
 import LabelsManager from '@/containers/map/content/map/labels-manager';
 import LayersToolbox from '@/containers/map/content/map/layers-toolbox';
@@ -39,7 +40,7 @@ const MainMap: React.FC = () => {
   const isSidebarOpen = useAtomValue(sidebarAtom);
   const [popup, setPopup] = useAtom(popupAtom);
   const params = useParams();
-  const locationBbox = useAtomValue(bboxLocation);
+  const [locationBbox, setLocationBbox] = useAtom(bboxLocation);
   const resetLocationBbox = useResetAtom(bboxLocation);
   const hoveredPolygonId = useRef<Parameters<typeof map.setFeatureState>[0] | null>(null);
   const [cursor, setCursor] = useState<'grab' | 'crosshair' | 'pointer'>('grab');
@@ -78,6 +79,10 @@ const MainMap: React.FC = () => {
       },
     }
   );
+
+  useEffect(() => {
+    setLocationBbox(locationsQuery?.data?.bounds as CustomMapProps['bounds']['bbox']);
+  }, [locationCode, locationsQuery, setLocationBbox]);
 
   const handleMoveEnd = useCallback(() => {
     setMapSettings((prev) => ({

--- a/frontend/src/containers/map/sidebar/main-panel/details/location-selector/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/details/location-selector/index.tsx
@@ -4,12 +4,11 @@ import { useRouter } from 'next/router';
 
 import { useSetAtom } from 'jotai';
 
-import { CustomMapProps } from '@/components/map/types';
 import { Button } from '@/components/ui/button';
 import Icon from '@/components/ui/icon';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { PAGES } from '@/constants/pages';
-import { bboxLocation, popupAtom } from '@/containers/map/store';
+import { popupAtom } from '@/containers/map/store';
 import { cn } from '@/lib/classnames';
 import GlobeIcon from '@/styles/icons/globe.svg';
 import MagnifyingGlassIcon from '@/styles/icons/magnifying-glass.svg';
@@ -46,7 +45,6 @@ const LocationSelector: React.FC<LocationSelectorProps> = ({ className }) => {
     query: { locationCode = 'GLOB' },
   } = useRouter();
 
-  const setLocationBBox = useSetAtom(bboxLocation);
   const setPopup = useSetAtom(popupAtom);
 
   const searchParams = useMapSearchParams();
@@ -75,19 +73,9 @@ const LocationSelector: React.FC<LocationSelectorProps> = ({ className }) => {
     async (locationCode: LocationGroupsDataItemAttributes['code']) => {
       setLocationPopoverOpen(false);
       setPopup({});
-
-      const selectedLocation = locationsData.find(
-        ({ attributes: { code } }) => code === locationCode
-      );
-
-      if (selectedLocation) {
-        setLocationBBox(selectedLocation?.attributes.bounds as CustomMapProps['bounds']['bbox']);
-        await push(
-          `${PAGES.progressTracker}/${locationCode.toUpperCase()}?${searchParams.toString()}`
-        );
-      }
+      push(`${PAGES.progressTracker}/${locationCode.toUpperCase()}?${searchParams.toString()}`);
     },
-    [push, searchParams, setLocationBBox, locationsData, setPopup]
+    [setPopup, push, searchParams]
   );
 
   const reorderedLocations = useMemo(() => {


### PR DESCRIPTION
### Overview

As it turns out, the map will not zoom into a selected country when clicking on a country in the list displayed on the sidebar header (eg: when location is selected to Africa region, the list of countries that is displayed). 

I've noticed that in the current implementation, when a user selects a location in the location selector, the bbox is set there, and then a new location is pushed via router. In other places, we're using a next/link. 

The change made here, was to make it so that the map will respond to location param changes, which would make the map zoom in into the selected location in all scenarios. 

### Feature relevant tickets

[SKY30-358](https://vizzuality.atlassian.net/browse/SKY30-358)

[SKY30-358]: https://vizzuality.atlassian.net/browse/SKY30-358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ