### PR TITLE
[SKY30-367] adds N/A fallback and filter option for establishment stage column

### DIFF
--- a/frontend/src/containers/map/content/details/tables/national-highseas/index.tsx
+++ b/frontend/src/containers/map/content/details/tables/national-highseas/index.tsx
@@ -103,7 +103,7 @@ const NationalHighseasTable: React.FC = () => {
         protectedArea: mpa?.name,
         coverage: coveragePercentage,
         protectedAreaType: protectionStatus?.slug,
-        establishmentStage: establishmentStage?.slug,
+        establishmentStage: establishmentStage?.slug || 'N/A',
         protectionLevel: mpaaProtectionLevel?.slug || 'unknown',
         fishingProtectionLevel: fishingProtectionLevel?.slug,
         area: coverageStats.area,

--- a/frontend/src/containers/map/content/details/tables/national-highseas/useColumns.tsx
+++ b/frontend/src/containers/map/content/details/tables/national-highseas/useColumns.tsx
@@ -132,9 +132,8 @@ const useColumns = ({ filters, onFiltersChange }: UseColumnsProps) => {
         ),
         cell: ({ row }) => {
           const { establishmentStage: value } = row.original;
-          const formattedValue = establishmentStageOptions.find(
-            (entry) => value === entry?.value
-          )?.name;
+          const formattedValue =
+            establishmentStageOptions.find((entry) => value === entry?.value)?.name || 'N/A';
           return <>{formattedValue}</>;
         },
       },

--- a/frontend/src/containers/map/content/details/tables/national-highseas/useFiltersOptions.ts
+++ b/frontend/src/containers/map/content/details/tables/national-highseas/useFiltersOptions.ts
@@ -29,7 +29,7 @@ const useFiltersOptions = () => {
     {},
     {
       query: {
-        select: ({ data }) => data,
+        select: ({ data }) => [...data, { attributes: { name: 'N/A', slug: 'N/A' } }],
         placeholderData: { data: [] },
       },
     }


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

![image](https://github.com/Vizzuality/skytruth-30x30/assets/999124/d147c891-0a89-4a25-83e3-227751eb414a)
![image](https://github.com/Vizzuality/skytruth-30x30/assets/999124/918c5e89-2c0f-47dd-8356-a50001cb3b1b)

- adds `N/A` fallback for `undefined` values. 
- adds a `N/A` option to Establishment Stage filter to be able to filter by this new value.

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/SKY30-367

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.