### PR TITLE
[SKY30-365] marine conservation widget: show target only for global view

### DIFF
--- a/frontend/src/containers/map/sidebar/main-panel/details/widgets/protection-types/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/details/widgets/protection-types/index.tsx
@@ -139,7 +139,7 @@ const ProtectionTypesWidget: React.FC<ProtectionTypesWidgetProps> = ({ location 
       {widgetChartData.map((chartData) => (
         <HorizontalBarChart
           key={chartData.slug}
-          showTarget={false}
+          showTarget={location?.code === 'GLOB'}
           className="py-2"
           data={chartData}
         />


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

This task was addressed [previously](https://github.com/Vizzuality/skytruth-30x30/commit/cae6960fc12d1d04f638afdef8f1916fecb7bd8b) but looks like [the criteria was wrong](https://vizzuality.atlassian.net/browse/SKY30-365?focusedCommentId=29307) so I am updating it.

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/SKY30-365

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.