### PR TITLE
[N/A] EEZ popup: deal with conflict zones

### DIFF
--- a/frontend/src/containers/map/content/map/popup/generic/index.tsx
+++ b/frontend/src/containers/map/content/map/popup/generic/index.tsx
@@ -10,10 +10,7 @@ import { format } from '@/lib/utils/formats';
 import { useGetLayersId } from '@/types/generated/layer';
 import { LayerTyped, InteractionConfig } from '@/types/layers';
 
-const GenericPopup = ({
-  locationId,
-  ...restConfig
-}: InteractionConfig & { locationId: number }) => {
+const GenericPopup = ({ layerId, ...restConfig }: InteractionConfig & { layerId: number }) => {
   const [rendered, setRendered] = useState(false);
   const DATA_REF = useRef<Feature['properties'] | undefined>();
   const { default: map } = useMap();
@@ -23,7 +20,7 @@ const GenericPopup = ({
   const layersInteractiveIds = useAtomValue(layersInteractiveIdsAtom);
 
   const layerQuery = useGetLayersId(
-    locationId,
+    layerId,
     {
       populate: 'metadata',
     },

--- a/frontend/src/containers/map/content/map/popup/item.tsx
+++ b/frontend/src/containers/map/content/map/popup/item.tsx
@@ -20,7 +20,7 @@ const PopupItem = ({ id }: PopupItemProps) => {
     const l = parseConfig<InteractionConfig | ReactElement | null>({
       config: {
         ...interaction_config,
-        locationId: id,
+        layerId: id,
       },
       params_config,
       settings: {},

--- a/frontend/src/containers/map/content/map/popup/protected-area/index.tsx
+++ b/frontend/src/containers/map/content/map/popup/protected-area/index.tsx
@@ -14,7 +14,7 @@ import { LayerTyped } from '@/types/layers';
 
 const TERMS_CLASSES = 'font-mono uppercase';
 
-const ProtectedAreaPopup = ({ locationId }: { locationId: number }) => {
+const ProtectedAreaPopup = ({ layerId }: { layerId: number }) => {
   const [rendered, setRendered] = useState(false);
   const DATA_REF = useRef<Feature['properties'] | undefined>();
   const { default: map } = useMap();
@@ -23,7 +23,7 @@ const ProtectedAreaPopup = ({ locationId }: { locationId: number }) => {
   const layersInteractiveIds = useAtomValue(layersInteractiveIdsAtom);
 
   const layerQuery = useGetLayersId(
-    locationId,
+    layerId,
     {
       populate: 'metadata',
     },

--- a/frontend/src/containers/map/content/map/popup/regions/index.tsx
+++ b/frontend/src/containers/map/content/map/popup/regions/index.tsx
@@ -18,7 +18,7 @@ import { useGetProtectionCoverageStats } from '@/types/generated/protection-cove
 import { ProtectionCoverageStatListResponseDataItem } from '@/types/generated/strapi.schemas';
 import { LayerTyped } from '@/types/layers';
 
-const EEZLayerPopup = ({ locationId }) => {
+const RegionsPopup = ({ layerId }) => {
   const [rendered, setRendered] = useState(false);
   const DATA_REF = useRef<Feature['properties'] | undefined>();
   const { default: map } = useMap();
@@ -30,7 +30,7 @@ const EEZLayerPopup = ({ locationId }) => {
   const layersInteractiveIds = useAtomValue(layersInteractiveIdsAtom);
 
   const layerQuery = useGetLayersId(
-    locationId,
+    layerId,
     {
       populate: 'metadata',
     },
@@ -224,4 +224,4 @@ const EEZLayerPopup = ({ locationId }) => {
   );
 };
 
-export default EEZLayerPopup;
+export default RegionsPopup;


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

This PR modifies the behavior of the EEZ layer popup slightly: 
- when clicking on a conflict zone (like Maldivas), if the user is in the global view, it will not show any data
- if the case of Maldivas, if the user has Argentina selected, clicking on Maldivas will show the same percentage of protected areas as Argentina.
- if the case of Maldivas, if the user has United Kingdom selected, clicking on Maldivas will show the same percentage of protected areas as United Kingdom.

This behavior should apply to any conflictive zone.

### Designs
–

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

_Link to the related task manager tickets_

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.