### PR TITLE
[SKY30-370] Remove 'Data tools.' from the knowledge hub title

### DIFF
--- a/frontend/src/pages/knowledge-hub.tsx
+++ b/frontend/src/pages/knowledge-hub.tsx
@@ -43,10 +43,7 @@ const KnowledgeHubPage = () => {
       <Content>
         <Section ref={sectionRef} borderTop={false} className="py-0 md:mb-0">
           <div className="space-y-24">
-            <h2 className="text-[52px] font-black leading-none">
-              I am looking for...
-              <br /> Data tools.
-            </h2>
+            <h2 className="text-[52px] font-black leading-none">I am looking for...</h2>
             <div className="space-y-4">
               <CardFilters />
               <CardList />


### PR DESCRIPTION
### Overview

This PR removes the _"Data tools"_ from the Knowledge hub title

### Feature relevant tickets

[SKY30-370](https://vizzuality.atlassian.net/browse/SKY30-370)


[SKY30-370]: https://vizzuality.atlassian.net/browse/SKY30-370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ