### PR TITLE
[SKY30-376] Percentages to always display one decimal place (even if it's 0)

### DIFF
--- a/frontend/src/lib/utils/formats.ts
+++ b/frontend/src/lib/utils/formats.ts
@@ -11,10 +11,11 @@ export function formatPercentage(
   // Sanity check to prevent the display of percentages over 100.
   // This should never be true, but data can be wonky hence this last resort check.
   if (value > 100) {
-    return displayPercentageSign ? '100%' : '100';
+    return displayPercentageSign ? '100.0%' : '100.0';
   }
 
   const v = Intl.NumberFormat('en-US', {
+    minimumFractionDigits: 1,
     maximumFractionDigits: 1,
     style: displayPercentageSign ? 'percent' : 'decimal',
     ...intlNumberFormatOptions,


### PR DESCRIPTION
### Overview

This PR makes it so that percentages always display a decimal place, even if it's zero. 

This is done for consistency purposes, so it was done in the formatter and changes will be reflected anywhere in the app (with an exception for values stored in Strapi which is the case for many values in the static pages, in which case they have to be updated manually, as usual). 

### Designs

<img width="466" alt="PastedGraphic-1" src="https://github.com/Vizzuality/skytruth-30x30/assets/6273795/180ec5ea-b49f-4d11-a4bf-89a939d38008">

![Screenshot 2024-05-28 at 12 18 02](https://github.com/Vizzuality/skytruth-30x30/assets/6273795/19861959-bc9c-4ab7-a1b9-dd906d992495)

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

[SKY30-376](https://vizzuality.atlassian.net/browse/SKY30-376)

[SKY30-376]: https://vizzuality.atlassian.net/browse/SKY30-376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ