### PR TITLE
[SKY30-377] Marine Conservation Protection Levels to display the correct last update data

### DIFF
--- a/frontend/src/containers/map/sidebar/main-panel/details/widgets/protection-types/constants.ts
+++ b/frontend/src/containers/map/sidebar/main-panel/details/widgets/protection-types/constants.ts
@@ -1,0 +1,4 @@
+export const PROTECTION_LEVEL_NAME_SUBSTITUTIONS = {
+  'fully-highly-protected': 'Fully or highly protected',
+  'less-protected-unknown': 'Less protected or unknown',
+};

--- a/frontend/src/containers/map/sidebar/main-panel/details/widgets/protection-types/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/details/widgets/protection-types/index.tsx
@@ -49,31 +49,6 @@ const ProtectionTypesWidget: React.FC<ProtectionTypesWidgetProps> = ({ location 
     }
   );
 
-  // const { data: metadataWidget } = useGetDataInfos(
-  //   {
-  //     filters: {
-  //       slug: 'protection-levels-widget',
-  //     },
-  //     populate: 'data_sources',
-  //   },
-  //   {
-  //     query: {
-  //       select: ({ data }) =>
-  //         data[0]
-  //           ? {
-  //               info: data[0].attributes.content,
-  //               sources: data[0].attributes?.data_sources?.data?.map(
-  //                 ({ attributes: { title, url } }) => ({
-  //                   title,
-  //                   url,
-  //                 })
-  //               ),
-  //             }
-  //           : undefined,
-  //     },
-  //   }
-  // );
-
   const { data: metadata } = useGetDataInfos(
     {
       filters: {
@@ -137,8 +112,6 @@ const ProtectionTypesWidget: React.FC<ProtectionTypesWidgetProps> = ({ location 
       lastUpdated={protectionLevelsData[0]?.attributes?.updatedAt}
       noData={noData}
       loading={loading}
-      // info={metadataWidget?.info}
-      // sources={metadataWidget?.sources}
     >
       {widgetChartData.map((chartData) => (
         <HorizontalBarChart

--- a/frontend/src/containers/map/sidebar/main-panel/details/widgets/protection-types/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/details/widgets/protection-types/index.tsx
@@ -74,6 +74,18 @@ const ProtectionTypesWidget: React.FC<ProtectionTypesWidgetProps> = ({ location 
     }
   );
 
+  // Go through all the relevant stats, find the last updated one's value
+  const lastUpdated = useMemo(() => {
+    const protectionLevelStats =
+      protectionLevelsData[0]?.attributes?.mpaa_protection_level_stats?.data;
+    const updatedAtValues = protectionLevelStats?.reduce(
+      (acc, curr) => [...acc, curr?.attributes?.updatedAt],
+      []
+    );
+
+    return updatedAtValues?.sort()?.reverse()?.[0];
+  }, [protectionLevelsData]);
+
   // Parse data to display in the chart
   const widgetChartData = useMemo(() => {
     if (!protectionLevelsData.length) return [];
@@ -109,7 +121,7 @@ const ProtectionTypesWidget: React.FC<ProtectionTypesWidgetProps> = ({ location 
   return (
     <Widget
       title="Marine Conservation Protection Levels"
-      lastUpdated={protectionLevelsData[0]?.attributes?.updatedAt}
+      lastUpdated={lastUpdated}
       noData={noData}
       loading={loading}
     >

--- a/frontend/src/containers/map/sidebar/main-panel/details/widgets/protection-types/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/details/widgets/protection-types/index.tsx
@@ -7,6 +7,8 @@ import { useGetDataInfos } from '@/types/generated/data-info';
 import { useGetLocations } from '@/types/generated/location';
 import type { LocationGroupsDataItemAttributes } from '@/types/generated/strapi.schemas';
 
+import { PROTECTION_LEVEL_NAME_SUBSTITUTIONS } from './constants';
+
 type ProtectionTypesWidgetProps = {
   location: LocationGroupsDataItemAttributes;
 };
@@ -117,7 +119,9 @@ const ProtectionTypesWidget: React.FC<ProtectionTypesWidgetProps> = ({ location 
       protectionLevelsData[0]?.attributes?.mpaa_protection_level_stats?.data?.map((entry) => {
         const stats = entry?.attributes;
         const protectionLevel = stats?.mpaa_protection_level?.data.attributes;
-        return parsedProtectionLevel('Fully or highly protected', protectionLevel, stats);
+        const displayName =
+          PROTECTION_LEVEL_NAME_SUBSTITUTIONS[protectionLevel.slug] || protectionLevel?.name;
+        return parsedProtectionLevel(displayName, protectionLevel, stats);
       });
 
     return parsedMpaaProtectionLevelData;


### PR DESCRIPTION
### Overview

Frontend is using the `updatedAt` value from the protection levels data, instead of using the one from the mpaa protection level stats. This PR aims to fix that. 

**Notes:**  
- Commented out / obsolete code was removed  
  In the past the widget displayed other protection level data besides the mpaa stats. While the call remains the same (in case we need to change it back in the future), the obsolete/commented out code was removed. Most of the functions retain the functionality to deal with extra protection levels.   
- Improve how the frontend is dealing with the names of the different protection levels  
  We are not displaying the names returned by the endpoint; there are slight tweaks to them. In order to promote support for multiple protection levels (although we are only showing one right now, the "fully or highly protected"), I've tweaked things a little so that we can more easily rename the protection level names for display via a `constants.ts` file.  
- Displaying the "last updated on" field, now also supports multiple entries  
  Again, not necessary _yet_, but the FE will go through all mpaa entries, pick the "newest" update date, and display that as "last updated on".  

### Designs

<img width="458" alt="PastedGraphic-1 (1)" src="https://github.com/Vizzuality/skytruth-30x30/assets/6273795/fe164f9f-3073-4664-b53a-227f4ba3d522">

![Screenshot 2024-05-28 at 13 30 29](https://github.com/Vizzuality/skytruth-30x30/assets/6273795/9ace35f0-900b-4586-9a9f-a04cc5d9040f)


### Testing instructions

TODO

### Feature relevant tickets

[SKY30-377](https://vizzuality.atlassian.net/browse/SKY30-377)

[SKY30-377]: https://vizzuality.atlassian.net/browse/SKY30-377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ