### PR TITLE
[SKY30-383] Fix header links for static pages no longer displaying the "active" page arrow

### DIFF
--- a/frontend/src/components/active-link.tsx
+++ b/frontend/src/components/active-link.tsx
@@ -4,6 +4,8 @@
  */
 import React, { useState, useEffect, PropsWithChildren } from 'react';
 
+import { UrlObject } from 'url';
+
 import Link, { LinkProps } from 'next/link';
 import { useRouter } from 'next/router';
 
@@ -35,7 +37,12 @@ const ActiveLink: React.FC<ActiveLinkProps> = ({
       // Dynamic route will be matched via props.as
       // Static route will be matched via props.href
       const linkPathname = new URL(
-        `${(props.as as string) ?? (props.href as string)}`,
+        `${
+          (props.as as string) ??
+          (typeof props.href === 'string'
+            ? (props.href as string)
+            : ((props.href as UrlObject)?.pathname as string))
+        }`,
         window.location.href
       ).pathname;
 


### PR DESCRIPTION
### Overview

This PR fixes the header links no longer displaying the "active" icon, when a static page is selected. 

The issue was introduced in #264, specifically in the inclusion of [this code](https://github.com/Vizzuality/skytruth-30x30/pull/264/files#diff-b50fc27f55e5446e9e46c6d2e3f9558139210f0c46acda75e4dafdb1b2711ba4R87-R102) in order to pass settings via links while hiding them from the user. 

**Note:** This PR was also tested for when we have the language in the url (eg: https://skytruth-30x30-git-sky30-383-header-links-no-45f06c-vizzuality1.vercel.app/fr/knowledge-hub)

### Testing instructions

1. Use the header links to navigate to a static page (eg: _Knowledge Hub_, _About_, _Contact_)  
2. Ensure a colorful arrow is displayed next to the link corresponding to the active static page  

### Screenshot  

![static-page-link](https://github.com/Vizzuality/skytruth-30x30/assets/6273795/973efa6c-4dbe-4e85-90ae-23812d98a22b)


### Feature relevant tickets

[SKY30-383](https://vizzuality.atlassian.net/browse/SKY30-383)


[SKY30-383]: https://vizzuality.atlassian.net/browse/SKY30-383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ