### PR TITLE
[SKY30-423] Marine Conservation Protection Levels not working

### DIFF
--- a/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/protection-types/constants.ts
+++ b/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/protection-types/constants.ts
@@ -1,4 +1,0 @@
-export const PROTECTION_LEVEL_NAME_SUBSTITUTIONS = {
-  'fully-highly-protected': 'Fully or highly protected',
-  'less-protected-unknown': 'Less protected or unknown',
-};

--- a/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/protection-types/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/protection-types/index.tsx
@@ -7,10 +7,8 @@ import Widget from '@/components/widget';
 import { PROTECTION_TYPES_CHART_COLORS } from '@/constants/protection-types-chart-colors';
 import { FCWithMessages } from '@/types';
 import { useGetDataInfos } from '@/types/generated/data-info';
-import { useGetLocations } from '@/types/generated/location';
+import { useGetMpaaProtectionLevelStats } from '@/types/generated/mpaa-protection-level-stat';
 import type { LocationGroupsDataItemAttributes } from '@/types/generated/strapi.schemas';
-
-import { PROTECTION_LEVEL_NAME_SUBSTITUTIONS } from './constants';
 
 type ProtectionTypesWidgetProps = {
   location: LocationGroupsDataItemAttributes;
@@ -22,28 +20,20 @@ const ProtectionTypesWidget: FCWithMessages<ProtectionTypesWidgetProps> = ({ loc
 
   // Get protection levels data for the location
   const {
-    data: { data: protectionLevelsData },
-    isFetching: isFetchingProtectionLevelsData,
-  } = useGetLocations(
+    data: { data: protectionLevelsStatsData },
+    isFetching: isFetchingProtectionLevelsStatsData,
+  } = useGetMpaaProtectionLevelStats(
     {
       locale,
       filters: {
-        code: location?.code,
-      },
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      populate: {
-        mpaa_protection_level_stats: {
-          filters: {
-            mpaa_protection_level: {
-              slug: 'fully-highly-protected',
-            },
-          },
-          populate: {
-            mpaa_protection_level: '*',
-          },
+        location: {
+          code: location?.code || 'GLOB',
+        },
+        mpaa_protection_level: {
+          slug: 'fully-highly-protected',
         },
       },
+      populate: '*',
       'pagination[limit]': -1,
     },
     {
@@ -84,47 +74,42 @@ const ProtectionTypesWidget: FCWithMessages<ProtectionTypesWidgetProps> = ({ loc
 
   // Go through all the relevant stats, find the last updated one's value
   const lastUpdated = useMemo(() => {
-    const protectionLevelStats =
-      protectionLevelsData[0]?.attributes?.mpaa_protection_level_stats?.data;
-    const updatedAtValues = protectionLevelStats?.reduce(
+    const updatedAtValues = protectionLevelsStatsData?.reduce(
       (acc, curr) => [...acc, curr?.attributes?.updatedAt],
       []
     );
 
     return updatedAtValues?.sort()?.reverse()?.[0];
-  }, [protectionLevelsData]);
+  }, [protectionLevelsStatsData]);
 
   // Parse data to display in the chart
   const widgetChartData = useMemo(() => {
-    if (!protectionLevelsData.length) return [];
+    if (!protectionLevelsStatsData.length) return [];
 
-    const parsedProtectionLevel = (label, protectionLevel, stats) => {
+    const parseProtectionLevelStats = (protectionLevelStats) => {
+      const mpaaProtectionLevel = protectionLevelStats?.mpaa_protection_level?.data?.attributes;
+      const location = protectionLevelStats?.location?.data?.attributes;
+
+      const barColor = PROTECTION_TYPES_CHART_COLORS[mpaaProtectionLevel?.slug];
+
       return {
-        title: label,
-        slug: protectionLevel.slug,
-        background: PROTECTION_TYPES_CHART_COLORS[protectionLevel.slug],
-        totalArea: location.totalMarineArea,
-        protectedArea: stats?.area,
+        title: mpaaProtectionLevel?.name,
+        slug: mpaaProtectionLevel?.slug,
+        background: barColor,
+        totalArea: location?.totalMarineArea,
+        protectedArea: protectionLevelStats?.area,
         info: metadata?.info,
         sources: metadata?.sources,
       };
     };
 
-    const parsedMpaaProtectionLevelData =
-      protectionLevelsData[0]?.attributes?.mpaa_protection_level_stats?.data?.map((entry) => {
-        const stats = entry?.attributes;
-        const protectionLevel = stats?.mpaa_protection_level?.data.attributes;
-        const displayName =
-          PROTECTION_LEVEL_NAME_SUBSTITUTIONS[protectionLevel.slug] || protectionLevel?.name;
-        return parsedProtectionLevel(displayName, protectionLevel, stats);
-      });
-
-    return parsedMpaaProtectionLevelData;
-  }, [location, protectionLevelsData, metadata]);
+    return protectionLevelsStatsData?.map(({ attributes }) =>
+      parseProtectionLevelStats(attributes)
+    );
+  }, [metadata, protectionLevelsStatsData]);
 
   const noData = !widgetChartData.length;
-
-  const loading = isFetchingProtectionLevelsData;
+  const loading = isFetchingProtectionLevelsStatsData;
 
   return (
     <Widget


### PR DESCRIPTION
### Overview

This PR changes the API call so that we fetch data from the `MpaaProtectionLevelStats` endpoint (and populate what we need, `Location` and `MpaaProtectionLevel`), instead of querying the `Location` endpoint. 

The reasoning for this "fix" is because after the last data update, the associations in Strapi have changed populating the stats from the location endpoint no longer works (whether intended or a bug, the associations are just not there). This is a quick fix so we get the widget back online quickly. 

An added benefit, is that with this change we reduce the nesting in the query and simplify parsing the data a little bit. It will also make it easier to localize the entries. 


### Feature relevant tickets

[SKY30-423](https://vizzuality.atlassian.net/browse/SKY30-423)

[SKY30-423]: https://vizzuality.atlassian.net/browse/SKY30-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ