### PR TITLE
[SKY30-422]Hide layer preview data from details columns

### DIFF
--- a/frontend/src/containers/map/content/details/tables/national-highseas/index.tsx
+++ b/frontend/src/containers/map/content/details/tables/national-highseas/index.tsx
@@ -128,11 +128,12 @@ const NationalHighseasTable: FCWithMessages = () => {
         area: mpa?.area,
         dataSource: dataSource?.slug,
         iucnCategory: iucnCategory?.slug,
-        map: {
-          wdpaId: mpa?.wdpaid,
-          bounds: mpa?.bbox,
-          dataSource: dataSource?.slug,
-        },
+        // ? LayerPreview: We're not displaying the layer preview at this moment, but we want to preserve the code
+        // map: {
+        //   wdpaId: mpa?.wdpaid,
+        //   bounds: mpa?.bbox,
+        //   dataSource: dataSource?.slug,
+        // },
       };
     };
 
@@ -157,7 +158,7 @@ const NationalHighseasTable: FCWithMessages = () => {
 
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
-  return <Table columns={columns} data={tableData} columnSeparators={['map']} />;
+  return <Table columns={columns} data={tableData} />;
 };
 
 NationalHighseasTable.messages = [

--- a/frontend/src/containers/map/content/details/tables/national-highseas/useColumns.tsx
+++ b/frontend/src/containers/map/content/details/tables/national-highseas/useColumns.tsx
@@ -71,25 +71,26 @@ const useColumns = ({ filters, onFiltersChange }: UseColumnsProps) => {
           );
         },
       },
-      {
-        accessorKey: 'map',
-        header: null,
-        cell: ({ row }) => {
-          const { bounds, wdpaId, dataSource } = row.original?.map || {};
+      // ? LayerPreview: We're not displaying the layer preview at this moment, but we want to preserve the code
+      // {
+      //   accessorKey: 'map',
+      //   header: null,
+      //   cell: ({ row }) => {
+      //     const { bounds, wdpaId, dataSource } = row.original?.map || {};
 
-          return (
-            <div className="relative -mr-0.5 h-[calc(100%+4px)] w-12 border-l border-r border-t border-b border-black">
-              <LayerPreview
-                {...{
-                  wdpaId,
-                  bounds,
-                  dataSource,
-                }}
-              />
-            </div>
-          );
-        },
-      },
+      //     return (
+      //       <div className="relative -mr-0.5 h-[calc(100%+4px)] w-12 border-l border-r border-t border-b border-black">
+      //         <LayerPreview
+      //           {...{
+      //             wdpaId,
+      //             bounds,
+      //             dataSource,
+      //           }}
+      //         />
+      //       </div>
+      //     );
+      //   },
+      // },
       {
         accessorKey: 'coverage',
         header: ({ column }) => (


### PR DESCRIPTION
### Overview

Map thumbnails are being problematic and client wants to hide them. 
Development team still hasn't gone through all the possibilities, so a middle ground was discussed:  

- We retain the code  
- We retain all the functionality  
- We comment out the column code for when we revisit this once we have more capacity  

**Notes:**  
- Any processing related to this task has been commented with the same comment, so it's easier for future developers (us) to find it and revert it. 

### Feature relevant tickets

[SKY30-422](https://vizzuality.atlassian.net/browse/SKY30-422)

[SKY30-422]: https://vizzuality.atlassian.net/browse/SKY30-422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ