### PR TITLE
Take sub rows into account when filtering in the tables

### DIFF
--- a/frontend/src/containers/map/content/details/helpers.ts
+++ b/frontend/src/containers/map/content/details/helpers.ts
@@ -1,10 +1,46 @@
-export const applyFilters = (data, filters) => {
-  const filteredData = data?.filter((item) => {
+type Row = { [key: string]: unknown };
+type Rows = (Row & { subRows?: Row[] })[];
+type Filters = Record<string, string[]>;
+
+export const applyFilters = (data: Rows, filters: Filters) => {
+  const filteredData = [];
+
+  for (const row of data) {
+    let keep = true; // Whether the row is kept or filtered out
+    let filteredSubRows = row.subRows;
+
     for (const key in filters) {
-      if (!filters[key].length) continue;
-      if (!filters[key].includes(item[key])) return false;
+      // If the filter doesn't have any value, we look at the next filter
+      if (!filters[key].length) {
+        continue;
+      }
+
+      // We apply the filters to the sub rows using recursion
+      if (filteredSubRows?.length) {
+        filteredSubRows = applyFilters(filteredSubRows, filters);
+      }
+
+      // If the row's value doesn't match any of the filter's value and the number of matching sub
+      // rows (if any) is 0, the row is filtered out
+      if (
+        !filters[key].includes(row[key] as string) &&
+        (!filteredSubRows || filteredSubRows.length === 0)
+      ) {
+        keep = false;
+        break;
+      }
     }
-    return true;
-  });
+
+    if (keep) {
+      // We create a new row to define a new list of sub rows, if any
+      const newRow = { ...row };
+      if (filteredSubRows) {
+        newRow.subRows = filteredSubRows;
+      }
+
+      filteredData.push(newRow);
+    }
+  }
+
   return filteredData;
 };


### PR DESCRIPTION
## Overview

This PR makes sure that when filters are applied to the tables, the sub rows are also consequently filtered.

## Testing instructions

1. Open `/progress-tracker/ABNJ`
2. Open the table view
3. Filter the table so that some sub rows would be filtered out
4. Filter the table so that some sub rows match the filters even if the main rows don't

## Feature relevant tickets

[SKY30-433](https://vizzuality.atlassian.net/browse/SKY30-433)

[SKY30-433]: https://vizzuality.atlassian.net/browse/SKY30-433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ