### PR TITLE
Display fallback for the “Type” column in the “Areas Beyond National Jurisdiction” table

### DIFF
--- a/frontend/src/containers/map/content/details/tables/national-highseas/useColumns.tsx
+++ b/frontend/src/containers/map/content/details/tables/national-highseas/useColumns.tsx
@@ -172,7 +172,7 @@ const useColumns = ({ filters, onFiltersChange }: UseColumnsProps) => {
           const formattedValue = protectionStatusOptions.find(
             (entry) => value === entry?.value
           )?.name;
-          return <>{formattedValue}</>;
+          return <>{formattedValue ?? '-'}</>;
         },
       },
       {


### PR DESCRIPTION
## Overview

The “Type” column of the “Areas Beyond National Jurisdiction” table was empty for the rows for which the data comes from MPAtlas. Instead of displaying empty cells, this PR fallbacks to displaying `-`.

## Testing instructions

1. Open the table on `/progress-tracker/ABNJ`
2. Open the sub rows

## Feature relevant tickets

[SKY30-435](https://vizzuality.atlassian.net/browse/SKY30-435)

[SKY30-435]: https://vizzuality.atlassian.net/browse/SKY30-435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ