### PR TITLE
Add the Fishing Protection widget back

### DIFF
--- a/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/index.tsx
@@ -7,12 +7,12 @@ import { cn } from '@/lib/classnames';
 import { FCWithMessages } from '@/types';
 import { useGetLocations } from '@/types/generated/location';
 
+import FishingProtectionWidget from './fishing-protection';
 import HabitatWidget from './habitat';
 import MarineConservationWidget from './marine-conservation';
 import ProtectionTypesWidget from './protection-types';
 
 // import EstablishmentStagesWidget from './establishment-stages';
-// import FishingProtectionWidget from './fishing-protection';
 
 const DetailsWidgets: FCWithMessages = () => {
   const locale = useLocale();
@@ -39,7 +39,7 @@ const DetailsWidgets: FCWithMessages = () => {
     >
       <MarineConservationWidget location={locationsData?.data[0]?.attributes} />
       <ProtectionTypesWidget location={locationsData?.data[0]?.attributes} />
-      {/* <FishingProtectionWidget location={locationsData?.data[0]?.attributes} /> */}
+      <FishingProtectionWidget location={locationsData?.data[0]?.attributes} />
       {/* <EstablishmentStagesWidget location={locationsData?.data[0]?.attributes} /> */}
       <HabitatWidget location={locationsData?.data[0]?.attributes} />
     </div>

--- a/frontend/translations/en.json
+++ b/frontend/translations/en.json
@@ -215,7 +215,9 @@
       "new-added-area": "New added area",
       "administrative-boundary": "Administrative boundary",
       "national-level-contribution": "National level contribution",
-      "global": "Global"
+      "global": "Global",
+      "fishing-protection": "Fishing Protection",
+      "highly-protected-from-fishing": "Highly protected from fishing"
     },
     "map-sidebar-layers-panel": {
       "layers": "Layers",


### PR DESCRIPTION
This PR adds back the Fishing Protection widget and uses the latest model changes that include the percentage of protected area. The total area provided by the “Location” model is not used anymore.

The request to Strapi is unnecessarily convoluted because of limitations to the way Strapi handles relations between localised and non-localised models. I added comments in the code to explain this.

## Tracking

[SKY30-441](https://vizzuality.atlassian.net/browse/SKY30-441)

[SKY30-441]: https://vizzuality.atlassian.net/browse/SKY30-441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ