### PR TITLE
Allow Strapi to return more rows at once (up to 100 000)

### DIFF
--- a/cms/config/api.ts
+++ b/cms/config/api.ts
@@ -1,7 +1,7 @@
 export default {
   rest: {
     defaultLimit: 25,
-    maxLimit: 300,
+    maxLimit: 100000, // Limit can't be below around 30k
     withCount: true,
   },
 };


### PR DESCRIPTION
This PR increases the maximum number of rows returned by Strapi to 100 000 in order to make sure that all the protected areas of a country are listed in the details table.

The number 100 000 is arbitrary but we already know that we'll have up to 26k rows when all the terrestrial data is ingested.

## Testing instructions

Open the details table of France. Using the staging API, 475 rows should be rendered in the table.

## Tracking

[SKY30-447](https://vizzuality.atlassian.net/browse/SKY30-447)

[SKY30-447]: https://vizzuality.atlassian.net/browse/SKY30-447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ