### PR TITLE
Correctly sort accented strings in tables

### DIFF
--- a/frontend/src/containers/map/content/details/table/index.tsx
+++ b/frontend/src/containers/map/content/details/table/index.tsx
@@ -7,7 +7,7 @@ import {
   getSortedRowModel,
   useReactTable,
 } from '@tanstack/react-table';
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 
 import { cn } from '@/lib/classnames';
 import { FCWithMessages } from '@/types';
@@ -16,6 +16,7 @@ import { FCWithMessages } from '@/types';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 const MapTable: FCWithMessages = ({ columns, data, columnSeparators = null }) => {
+  const locale = useLocale();
   const t = useTranslations('containers.map');
 
   const tableRef = useRef<HTMLTableElement>();
@@ -36,6 +37,13 @@ const MapTable: FCWithMessages = ({ columns, data, columnSeparators = null }) =>
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getExpandedRowModel: getExpandedRowModel(),
+    sortingFns: {
+      localeStringCompare: (rowA, rowB, columnId) =>
+        (rowA.original[columnId] as string).localeCompare(
+          rowB.original[columnId as string],
+          locale
+        ),
+    },
   });
 
   const hasData = table.getRowModel().rows?.length > 0;

--- a/frontend/src/containers/map/content/details/tables/global-regional/useColumns.tsx
+++ b/frontend/src/containers/map/content/details/tables/global-regional/useColumns.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 
 import Link from 'next/link';
 
-import { ColumnDef } from '@tanstack/react-table';
+import { ColumnDef, SortingFnOption } from '@tanstack/react-table';
 import { useLocale } from 'next-intl';
 import { useTranslations } from 'next-intl';
 
@@ -38,6 +38,7 @@ const useColumns = () => {
     return [
       {
         accessorKey: 'location',
+        sortingFn: 'localeStringCompare' as SortingFnOption<GlobalRegionalTableColumns>,
         header: ({ column }) => (
           <HeaderItem className="ml-1">
             <SortingButton column={column} />

--- a/frontend/src/containers/map/content/details/tables/national-highseas/useColumns.tsx
+++ b/frontend/src/containers/map/content/details/tables/national-highseas/useColumns.tsx
@@ -1,6 +1,6 @@
 import { ComponentProps, useMemo } from 'react';
 
-import { ColumnDef } from '@tanstack/react-table';
+import { ColumnDef, SortingFnOption } from '@tanstack/react-table';
 import { useLocale, useTranslations } from 'next-intl';
 
 import FiltersButton from '@/components/filters-button';
@@ -53,6 +53,7 @@ const useColumns = ({ filters, onFiltersChange }: UseColumnsProps) => {
     return [
       {
         accessorKey: 'protectedArea',
+        sortingFn: 'localeStringCompare' as SortingFnOption<NationalHighseasTableColumns>,
         header: ({ column }) => (
           <HeaderItem className="ml-6">
             <SortingButton column={column} />


### PR DESCRIPTION
This PR ensures that accented strings (à, é, è, etc.) are correctly sorted in the tables according to their locale. The PR makes use of `String.prototype.localeCompare()` to perform the sort.

## Testing instructions

1. Open the country profile of France
2. Open the details table

The names of the protected areas that start with an accent should be located next to the areas that don't have an accent. For example, «Étang» should be located close to «Etang».

## Tracking

[SKY30-448](https://vizzuality.atlassian.net/browse/SKY30-448)

[SKY30-448]: https://vizzuality.atlassian.net/browse/SKY30-448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ