### PR TITLE
Complete the sidebar with the terrestrial widget

### DIFF
--- a/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##protection-coverage-stat.protection-coverage-stat.json
+++ b/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##protection-coverage-stat.protection-coverage-stat.json
@@ -181,12 +181,6 @@
       }
     },
     "layouts": {
-      "list": [
-        "id",
-        "location",
-        "protection_status",
-        "year"
-      ],
       "edit": [
         [
           {
@@ -222,6 +216,13 @@
             "size": 6
           }
         ]
+      ],
+      "list": [
+        "id",
+        "location",
+        "environment",
+        "year",
+        "protection_status"
       ]
     }
   },

--- a/cms/config/sync/user-role.public.json
+++ b/cms/config/sync/user-role.public.json
@@ -49,6 +49,12 @@
       "action": "api::dataset.dataset.findOne"
     },
     {
+      "action": "api::environment.environment.find"
+    },
+    {
+      "action": "api::environment.environment.findOne"
+    },
+    {
       "action": "api::fishing-protection-level-stat.fishing-protection-level-stat.find"
     },
     {

--- a/frontend/src/components/charts/conservation-chart/index.tsx
+++ b/frontend/src/components/charts/conservation-chart/index.tsx
@@ -86,9 +86,12 @@ const ConservationChart: FCWithMessages<ConservationChartProps> = ({
   // Calculate data for the historical line; first and active year are known, years in between
   // need to be extrapolated.
   const historicalLineData = useMemo(() => {
-    const missingYearsArr = [...Array(activeYearData.year - firstYearData.year - 1).keys()].map(
-      (i) => i + firstYearData.year + 1
-    );
+    const missingYearsArr =
+      activeYearData.year === firstYearData.year
+        ? []
+        : [...Array(activeYearData.year - firstYearData.year - 1).keys()].map(
+            (i) => i + firstYearData.year + 1
+          );
 
     const extrapolatedHistoricalYears = missingYearsArr.map((year, idx) => {
       return {

--- a/frontend/src/constants/habitat-chart-colors.ts
+++ b/frontend/src/constants/habitat-chart-colors.ts
@@ -1,3 +1,4 @@
+// The order of the keys affect the order of the habitats in the habitat widget
 export const HABITAT_CHART_COLORS = {
   'warm-water corals': '#EC7667',
   'cold-water corals': '#3ACBF9',
@@ -5,4 +6,12 @@ export const HABITAT_CHART_COLORS = {
   seagrasses: '#2DBA66',
   saltmarshes: '#6D7600',
   seamounts: '#884B02',
+  forest: '#01550E',
+  savanna: '#E6CC8A',
+  shrubland: '#C6FF53',
+  grassland: '#1D931D',
+  'wetlands-open-waters': '#5BB5FF',
+  'rocky-mountains': '#95908C',
+  desert: '#FBF8D6',
+  artificial: '#67FFE2',
 };

--- a/frontend/src/containers/map/content/details/tables/global-regional/index.tsx
+++ b/frontend/src/containers/map/content/details/tables/global-regional/index.tsx
@@ -79,7 +79,7 @@ const GlobalRegionalTable: FCWithMessages = () => {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       populate: {
-        // This part if for the English version only
+        // This part is for the English version only
         protection_coverage_stats: {
           fields: ['cumSumProtectedArea', 'protectedAreasCount', 'year'],
           populate: {

--- a/frontend/src/containers/map/sidebar/main-panel/location-selector/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/location-selector/index.tsx
@@ -26,17 +26,19 @@ export const FILTERS = {
 };
 
 const BUTTON_CLASSES =
-  'font-mono text-xs px-0 font-semibold no-underline normal-case ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black focus-visible:ring-offset-2';
+  'font-mono text-xs px-0 font-semibold no-underline normal-case ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black focus-visible:ring-offset-2 transition-all';
 
 type LocationSelectorProps = {
   className?: HTMLDivElement['className'];
   theme: 'orange' | 'blue';
+  size?: 'default' | 'small';
   onChange: (locationCode: string) => void;
 };
 
 const LocationSelector: FCWithMessages<LocationSelectorProps> = ({
   className,
   theme,
+  size = 'default',
   onChange,
 }) => {
   const t = useTranslations('containers.map-sidebar-main-panel');
@@ -106,7 +108,11 @@ const LocationSelector: FCWithMessages<LocationSelectorProps> = ({
     <div className={cn('flex gap-3.5', className)}>
       <Popover open={locationPopoverOpen} onOpenChange={setLocationPopoverOpen}>
         <PopoverTrigger asChild>
-          <Button className={BUTTON_CLASSES} type="button" variant="text-link">
+          <Button
+            className={cn({ [BUTTON_CLASSES]: true, 'h-auto py-0': size === 'small' })}
+            type="button"
+            variant="text-link"
+          >
             <Icon icon={MagnifyingGlassIcon} className="mr-2 h-4 w-4 pb-px" />
             {t('change-location')}
           </Button>
@@ -128,7 +134,7 @@ const LocationSelector: FCWithMessages<LocationSelectorProps> = ({
       </Popover>
       {locationCode !== 'GLOB' && (
         <Button
-          className={BUTTON_CLASSES}
+          className={cn({ [BUTTON_CLASSES]: true, 'h-auto py-0': size === 'small' })}
           type="button"
           variant="text-link"
           onClick={() => handleLocationSelected('GLOB')}

--- a/frontend/src/containers/map/sidebar/main-panel/panels/details/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/panels/details/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 
 import { useRouter } from 'next/router';
 
@@ -15,11 +15,15 @@ import LocationSelector from '../../location-selector';
 
 import CountriesList from './countries-list';
 import DetailsButton from './details-button';
-import DetailsWidgets from './widgets';
+import MarineWidgets from './widgets/marine-widgets';
+import SummaryWidgets from './widgets/summary-widgets';
+import TerrestrialWidgets from './widgets/terrestrial-widgets';
 
 const SidebarDetails: FCWithMessages = () => {
   const locale = useLocale();
   const t = useTranslations('containers.map-sidebar-main-panel');
+
+  const tabsRef = useRef<HTMLDivElement | null>(null);
 
   const {
     push,
@@ -56,6 +60,12 @@ const SidebarDetails: FCWithMessages = () => {
     [setSettings]
   );
 
+  // Scroll to the top when the tab changes, whether that's initiated by clicking on the tab trigger
+  // or programmatically via `setSettings` in a different component
+  useEffect(() => {
+    tabsRef.current?.scrollTo({ top: 0 });
+  }, [tab]);
+
   return (
     <Tabs value={tab} onValueChange={handleTabChange} className="flex h-full w-full flex-col">
       <div className="shrink-0 border-b border-black bg-orange px-4 pt-4 md:px-8 md:pt-6">
@@ -68,15 +78,15 @@ const SidebarDetails: FCWithMessages = () => {
           <TabsTrigger value="marine">{t('marine')}</TabsTrigger>
         </TabsList>
       </div>
-      <div className="flex-grow overflow-y-auto">
+      <div ref={tabsRef} className="flex-grow overflow-y-auto">
         <TabsContent value="summary">
-          <div className="py-36 text-center font-black">{t('coming-soon')}</div>
+          <SummaryWidgets />
         </TabsContent>
         <TabsContent value="terrestrial">
-          <div className="py-36 text-center font-black">{t('coming-soon')}</div>
+          <TerrestrialWidgets />
         </TabsContent>
         <TabsContent value="marine">
-          <DetailsWidgets />
+          <MarineWidgets />
         </TabsContent>
       </div>
       <div className="shrink-0 border-t border-t-black px-4 py-5 md:px-8">
@@ -91,7 +101,8 @@ SidebarDetails.messages = [
   ...LocationSelector.messages,
   ...CountriesList.messages,
   ...DetailsButton.messages,
-  ...DetailsWidgets.messages,
+  ...SummaryWidgets.messages,
+  ...MarineWidgets.messages,
 ];
 
 export default SidebarDetails;

--- a/frontend/src/containers/map/sidebar/main-panel/panels/details/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/panels/details/index.tsx
@@ -70,15 +70,10 @@ const SidebarDetails: FCWithMessages = () => {
   }, [tab, locationCode]);
 
   return (
-    <Tabs
-      ref={containerRef}
-      value={tab}
-      onValueChange={handleTabChange}
-      className="h-full w-full overflow-y-auto"
-    >
+    <Tabs value={tab} onValueChange={handleTabChange} className="flex h-full w-full flex-col">
       <div
         className={cn({
-          'sticky top-0 z-10 flex gap-y-2 gap-x-5 border-b border-black bg-orange px-4 pt-4 md:px-8 md:pt-6':
+          'flex flex-shrink-0 gap-y-2 gap-x-5 border-b border-black bg-orange px-4 pt-4 md:px-8 md:pt-6':
             true,
           'flex-col': containerScroll === 0,
           'flex-row flex-wrap': containerScroll > 0,
@@ -100,7 +95,7 @@ const SidebarDetails: FCWithMessages = () => {
           onChange={handleLocationSelected}
         />
         <CountriesList
-          className="w-full flex-shrink-0"
+          className="w-full shrink-0"
           bgColorClassName="bg-orange"
           countries={memberCountries}
         />
@@ -110,7 +105,7 @@ const SidebarDetails: FCWithMessages = () => {
           <TabsTrigger value="marine">{t('marine')}</TabsTrigger>
         </TabsList>
       </div>
-      <div>
+      <div ref={containerRef} className="flex-grow overflow-y-auto">
         <TabsContent value="summary">
           <SummaryWidgets />
         </TabsContent>
@@ -121,7 +116,7 @@ const SidebarDetails: FCWithMessages = () => {
           <MarineWidgets />
         </TabsContent>
       </div>
-      <div className="sticky bottom-0 z-10 shrink-0 border-t border-t-black bg-white px-4 py-5 md:px-8">
+      <div className="shrink-0 border-t border-t-black bg-white px-4 py-5 md:px-8">
         <DetailsButton />
       </div>
     </Tabs>

--- a/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/fishing-protection/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/fishing-protection/index.tsx
@@ -5,6 +5,7 @@ import { useLocale, useTranslations } from 'next-intl';
 import HorizontalBarChart from '@/components/charts/horizontal-bar-chart';
 import Widget from '@/components/widget';
 import { FISHING_PROTECTION_CHART_COLORS } from '@/constants/fishing-protection-chart-colors';
+import { FCWithMessages } from '@/types';
 import { useGetDataInfos } from '@/types/generated/data-info';
 import { useGetLocations } from '@/types/generated/location';
 import type { LocationGroupsDataItemAttributes } from '@/types/generated/strapi.schemas';
@@ -13,7 +14,7 @@ type FishingProtectionWidgetProps = {
   location: LocationGroupsDataItemAttributes;
 };
 
-const FishingProtectionWidget: React.FC<FishingProtectionWidgetProps> = ({ location }) => {
+const FishingProtectionWidget: FCWithMessages<FishingProtectionWidgetProps> = ({ location }) => {
   const t = useTranslations('containers.map-sidebar-main-panel');
   const locale = useLocale();
 
@@ -34,7 +35,7 @@ const FishingProtectionWidget: React.FC<FishingProtectionWidgetProps> = ({ locat
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       populate: {
-        // This part if for the English version only
+        // This part is for the English version only
         fishing_protection_level_stats: {
           filters: {
             fishing_protection_level: {
@@ -180,5 +181,11 @@ const FishingProtectionWidget: React.FC<FishingProtectionWidgetProps> = ({ locat
     </Widget>
   );
 };
+
+FishingProtectionWidget.messages = [
+  'containers.map-sidebar-main-panel',
+  ...Widget.messages,
+  ...HorizontalBarChart.messages,
+];
 
 export default FishingProtectionWidget;

--- a/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/habitat/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/habitat/index.tsx
@@ -3,6 +3,7 @@ import { useLocale, useTranslations } from 'next-intl';
 import HorizontalBarChart from '@/components/charts/horizontal-bar-chart';
 import Widget from '@/components/widget';
 import { HABITAT_CHART_COLORS } from '@/constants/habitat-chart-colors';
+import { useSyncMapContentSettings } from '@/containers/map/sync-settings';
 import { FCWithMessages } from '@/types';
 import { useGetDataInfos } from '@/types/generated/data-info';
 import { useGetHabitatStats } from '@/types/generated/habitat-stat';
@@ -19,77 +20,89 @@ const HabitatWidget: FCWithMessages<HabitatWidgetProps> = ({ location }) => {
   const t = useTranslations('containers.map-sidebar-main-panel');
   const locale = useLocale();
 
-  const defaultQueryParams = {
-    filters: {
-      location: {
-        code: location?.code,
-      },
-    },
-  };
+  const [{ tab }] = useSyncMapContentSettings();
 
-  const { data: dataLastUpdate, isFetching: isFetchingDataLastUpdate } = useGetHabitatStats(
-    {
-      ...defaultQueryParams,
-      locale,
-      fields: 'updatedAt',
-      sort: 'updatedAt:desc',
-      'pagination[limit]': 1,
-    },
-    {
-      query: {
-        enabled: Boolean(location?.code),
-        select: ({ data }) => data?.[0]?.attributes?.updatedAt,
-        placeholderData: { data: null },
-        refetchOnWindowFocus: false,
-      },
-    }
-  );
-
-  const { data: habitatMetadatas } = useGetDataInfos(
+  const { data: habitatMetadatas } = useGetDataInfos<
+    { slug: string; info: string; sources?: { title: string; url: string }[] }[]
+  >(
     {
       locale,
       filters: {
-        slug: [
-          'cold-water corals',
-          'warm-water corals',
-          'mangroves',
-          'seagrasses',
-          'saltmarshes',
-          'mangroves',
-          'seamounts',
-        ],
+        slug: Object.keys(HABITAT_CHART_COLORS),
       },
-      populate: 'data_sources',
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      populate: {
+        data_sources: {
+          fields: ['title', 'url'],
+        },
+      },
+      sort: 'updatedAt:desc',
     },
     {
       query: {
         select: ({ data }) =>
-          data
-            ? data.map((item) => ({
-                slug: item.attributes.slug,
-                info: item.attributes.content,
-                sources: item.attributes?.data_sources?.data?.map(
-                  ({ attributes: { title, url } }) => ({
-                    title,
-                    url,
-                  })
-                ),
-              }))
-            : undefined,
+          data?.map((item) => ({
+            slug: item.attributes.slug,
+            info: item.attributes.content,
+            sources: item.attributes.data_sources?.data?.map(({ attributes: { title, url } }) => ({
+              title,
+              url,
+            })),
+          })) ?? [],
       },
     }
   );
 
-  const { data: widgetChartData, isFetching: isFetchingHabitatStatsData } = useGetHabitatStats(
+  const { data: chartData, isFetching } = useGetHabitatStats<
     {
-      ...defaultQueryParams,
+      title: string;
+      slug: string;
+      background: string;
+      totalArea: number;
+      protectedArea: number;
+      info?: string;
+      sources?: { title: string; url: string }[];
+      updatedAt: string;
+    }[]
+  >(
+    {
       locale,
-      populate: 'habitat,habitat.localizations',
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      populate: {
+        habitat: {
+          // This part is for the English version only
+          populate: {
+            // This part is for the Spanish and French versions
+            localizations: {
+              fields: ['slug', 'name', 'locale'],
+            },
+          },
+        },
+      },
       'pagination[limit]': -1,
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      fields: ['protectedArea', 'totalArea', 'updatedAt'],
+      filters: {
+        location: {
+          code: location?.code,
+        },
+        environment: {
+          slug: {
+            $eq: tab === 'marine' ? tab : 'terrestrial',
+          },
+        },
+      },
     },
     {
       query: {
         select: ({ data }) => {
+          if (!data) {
+            return [];
+          }
+
           const parsedData = data.map((entry) => {
             const stats = entry?.attributes;
 
@@ -110,56 +123,29 @@ const HabitatWidget: FCWithMessages<HabitatWidgetProps> = ({ location }) => {
               protectedArea: stats.protectedArea,
               info: metadata?.info,
               sources: metadata?.sources,
+              updatedAt: stats.updatedAt,
             };
           });
 
-          return parsedData.reverse();
+          return parsedData.sort((d1, d2) => {
+            const keys = Object.keys(HABITAT_CHART_COLORS);
+            return keys.indexOf(d1.slug) - keys.indexOf(d2.slug);
+          });
         },
-        placeholderData: { data: [] },
+        placeholderData: [],
         refetchOnWindowFocus: false,
       },
     }
   );
 
-  // const { data: metadataWidget } = useGetDataInfos(
-  //   {
-  //     locale,
-  //     filters: {
-  //       slug: 'habitats-widget',
-  //     },
-  //     populate: 'data_sources',
-  //   },
-  //   {
-  //     query: {
-  //       select: ({ data }) =>
-  //         data[0]
-  //           ? {
-  //               info: data[0].attributes.content,
-  //               sources: data[0].attributes?.data_sources?.data?.map(
-  //                 ({ attributes: { title, url } }) => ({
-  //                   title,
-  //                   url,
-  //                 })
-  //               ),
-  //             }
-  //           : undefined,
-  //     },
-  //   }
-  // );
-
-  const noData = !widgetChartData.length;
-  const loading = isFetchingHabitatStatsData || isFetchingDataLastUpdate;
-
   return (
     <Widget
       title={t('proportion-habitat-within-protected-areas')}
-      lastUpdated={dataLastUpdate}
-      noData={noData}
-      loading={loading}
-      // info={metadataWidget?.info}
-      // sources={metadataWidget?.sources}
+      lastUpdated={chartData[0]?.updatedAt}
+      noData={!chartData.length}
+      loading={isFetching}
     >
-      {widgetChartData.map((chartData) => (
+      {chartData.map((chartData) => (
         <HorizontalBarChart
           key={chartData.slug}
           className="py-2"

--- a/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/marine-widgets.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/marine-widgets.tsx
@@ -14,7 +14,7 @@ import ProtectionTypesWidget from './protection-types';
 
 // import EstablishmentStagesWidget from './establishment-stages';
 
-const DetailsWidgets: FCWithMessages = () => {
+const MarineWidgets: FCWithMessages = () => {
   const locale = useLocale();
 
   const {
@@ -23,12 +23,24 @@ const DetailsWidgets: FCWithMessages = () => {
 
   const [{ showDetails }] = useSyncMapContentSettings();
 
-  const { data: locationsData } = useGetLocations({
-    locale,
-    filters: {
-      code: locationCode,
+  const { data: locationData } = useGetLocations(
+    {
+      locale,
+      filters: {
+        code: locationCode,
+      },
+      'pagination[limit]': 1,
     },
-  });
+    {
+      query: {
+        select: ({ data }) => data[0]?.attributes ?? null,
+      },
+    }
+  );
+
+  if (!locationData) {
+    return null;
+  }
 
   return (
     <div
@@ -37,19 +49,20 @@ const DetailsWidgets: FCWithMessages = () => {
         'pb-40': showDetails,
       })}
     >
-      <MarineConservationWidget location={locationsData?.data[0]?.attributes} />
-      <ProtectionTypesWidget location={locationsData?.data[0]?.attributes} />
-      <FishingProtectionWidget location={locationsData?.data[0]?.attributes} />
-      {/* <EstablishmentStagesWidget location={locationsData?.data[0]?.attributes} /> */}
-      <HabitatWidget location={locationsData?.data[0]?.attributes} />
+      <MarineConservationWidget location={locationData} />
+      <ProtectionTypesWidget location={locationData} />
+      <FishingProtectionWidget location={locationData} />
+      {/* <EstablishmentStagesWidget location={locationData} /> */}
+      <HabitatWidget location={locationData} />
     </div>
   );
 };
 
-DetailsWidgets.messages = [
+MarineWidgets.messages = [
   ...MarineConservationWidget.messages,
   ...ProtectionTypesWidget.messages,
+  ...FishingProtectionWidget.messages,
   ...HabitatWidget.messages,
 ];
 
-export default DetailsWidgets;
+export default MarineWidgets;

--- a/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/summary-widgets.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/summary-widgets.tsx
@@ -1,0 +1,52 @@
+import { useRouter } from 'next/router';
+
+import { useLocale } from 'next-intl';
+
+import { useSyncMapContentSettings } from '@/containers/map/sync-settings';
+import { cn } from '@/lib/classnames';
+import { FCWithMessages } from '@/types';
+import { useGetLocations } from '@/types/generated/location';
+
+import MarineConservationWidget from './marine-conservation';
+import TerrestrialConservationWidget from './terrestrial-conservation';
+
+const SummaryWidgets: FCWithMessages = () => {
+  const locale = useLocale();
+
+  const {
+    query: { locationCode = 'GLOB' },
+  } = useRouter();
+
+  const [{ showDetails }] = useSyncMapContentSettings();
+
+  const { data: locationData } = useGetLocations(
+    {
+      locale,
+      filters: {
+        code: locationCode,
+      },
+      'pagination[limit]': 1,
+    },
+    {
+      query: {
+        select: ({ data }) => data[0]?.attributes ?? null,
+      },
+    }
+  );
+
+  return (
+    <div
+      className={cn({
+        'flex flex-col divide-y-[1px] divide-black font-mono': true,
+        'pb-40': showDetails,
+      })}
+    >
+      <TerrestrialConservationWidget location={locationData} />
+      <MarineConservationWidget location={locationData} />
+    </div>
+  );
+};
+
+SummaryWidgets.messages = [...MarineConservationWidget.messages];
+
+export default SummaryWidgets;

--- a/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/terrestrial-conservation/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/terrestrial-conservation/index.tsx
@@ -17,11 +17,13 @@ import type {
   ProtectionCoverageStatListResponseDataItem,
 } from '@/types/generated/strapi.schemas';
 
-type MarineConservationWidgetProps = {
+type TerrestrialConservationWidgetProps = {
   location: LocationGroupsDataItemAttributes;
 };
 
-const MarineConservationWidget: FCWithMessages<MarineConservationWidgetProps> = ({ location }) => {
+const TerrestrialConservationWidget: FCWithMessages<TerrestrialConservationWidgetProps> = ({
+  location,
+}) => {
   const t = useTranslations('containers.map-sidebar-main-panel');
   const locale = useLocale();
 
@@ -36,7 +38,7 @@ const MarineConservationWidget: FCWithMessages<MarineConservationWidgetProps> = 
       // @ts-ignore
       populate: {
         location: {
-          fields: ['code', 'totalMarineArea'],
+          fields: ['code', 'totalTerrestrialArea'],
         },
         environment: {
           fields: ['slug'],
@@ -55,7 +57,7 @@ const MarineConservationWidget: FCWithMessages<MarineConservationWidgetProps> = 
         },
         environment: {
           slug: {
-            $eq: 'marine',
+            $eq: 'terrestrial',
           },
         },
       },
@@ -157,7 +159,7 @@ const MarineConservationWidget: FCWithMessages<MarineConservationWidgetProps> = 
 
   return (
     <Widget
-      title={t('marine-conservation-coverage')}
+      title={t('terrestrial-conservation-coverage')}
       lastUpdated={data[data.length - 1]?.attributes.updatedAt}
       noData={!chartData.length}
       loading={isFetching}
@@ -167,7 +169,7 @@ const MarineConservationWidget: FCWithMessages<MarineConservationWidgetProps> = 
       {stats && (
         <div className="mt-6 mb-4 flex flex-col">
           <span className="space-x-1">
-            {t.rich('marine-protected-percentage', {
+            {t.rich('terrestrial-protected-percentage', {
               b1: (chunks) => <span className="text-[64px] font-bold leading-[90%]">{chunks}</span>,
               b2: (chunks) => <span className="text-lg">{chunks}</span>,
               percentage: stats?.protectedPercentage,
@@ -175,7 +177,7 @@ const MarineConservationWidget: FCWithMessages<MarineConservationWidgetProps> = 
           </span>
           <span className="space-x-1 text-xs">
             <span>
-              {t('marine-protected-area', {
+              {t('terrestrial-protected-area', {
                 protectedArea: stats?.protectedArea,
                 totalArea: stats?.totalArea,
               })}
@@ -188,15 +190,15 @@ const MarineConservationWidget: FCWithMessages<MarineConservationWidgetProps> = 
         displayTarget={location?.code === 'GLOB'}
         data={chartData}
       />
-      {tab !== 'marine' && (
+      {tab !== 'terrestrial' && (
         <Button
           variant="white"
           size="full"
           className="mt-5 flex h-10 px-5 md:px-8"
-          onClick={() => setSettings((settings) => ({ ...settings, tab: 'marine' }))}
+          onClick={() => setSettings((settings) => ({ ...settings, tab: 'terrestrial' }))}
         >
           <span className="font-mono text-xs font-semibold normal-case">
-            {t('explore-marine-conservation')}
+            {t('explore-terrestrial-conservation')}
           </span>
         </Button>
       )}
@@ -204,10 +206,10 @@ const MarineConservationWidget: FCWithMessages<MarineConservationWidgetProps> = 
   );
 };
 
-MarineConservationWidget.messages = [
+TerrestrialConservationWidget.messages = [
   'containers.map-sidebar-main-panel',
   ...Widget.messages,
   ...ConservationChart.messages,
 ];
 
-export default MarineConservationWidget;
+export default TerrestrialConservationWidget;

--- a/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/terrestrial-widgets.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/terrestrial-widgets.tsx
@@ -1,0 +1,54 @@
+import { useRouter } from 'next/router';
+
+import { useLocale } from 'next-intl';
+
+import { useSyncMapContentSettings } from '@/containers/map/sync-settings';
+import { cn } from '@/lib/classnames';
+import { FCWithMessages } from '@/types';
+import { useGetLocations } from '@/types/generated/location';
+
+import TerrestrialConservationWidget from './terrestrial-conservation';
+
+const TerrestrialWidgets: FCWithMessages = () => {
+  const locale = useLocale();
+
+  const {
+    query: { locationCode = 'GLOB' },
+  } = useRouter();
+
+  const [{ showDetails }] = useSyncMapContentSettings();
+
+  const { data: locationData } = useGetLocations(
+    {
+      locale,
+      filters: {
+        code: locationCode,
+      },
+      'pagination[limit]': 1,
+    },
+    {
+      query: {
+        select: ({ data }) => data[0]?.attributes ?? null,
+      },
+    }
+  );
+
+  if (!locationData) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn({
+        'flex flex-col divide-y-[1px] divide-black font-mono': true,
+        'pb-40': showDetails,
+      })}
+    >
+      <TerrestrialConservationWidget location={locationData} />
+    </div>
+  );
+};
+
+TerrestrialWidgets.messages = [...TerrestrialConservationWidget.messages];
+
+export default TerrestrialWidgets;

--- a/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/terrestrial-widgets.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/terrestrial-widgets.tsx
@@ -7,6 +7,7 @@ import { cn } from '@/lib/classnames';
 import { FCWithMessages } from '@/types';
 import { useGetLocations } from '@/types/generated/location';
 
+import HabitatWidget from './habitat';
 import TerrestrialConservationWidget from './terrestrial-conservation';
 
 const TerrestrialWidgets: FCWithMessages = () => {
@@ -45,6 +46,7 @@ const TerrestrialWidgets: FCWithMessages = () => {
       })}
     >
       <TerrestrialConservationWidget location={locationData} />
+      <HabitatWidget location={locationData} />
     </div>
   );
 };

--- a/frontend/src/hooks/use-scroll-position.ts
+++ b/frontend/src/hooks/use-scroll-position.ts
@@ -1,0 +1,22 @@
+import { MutableRefObject, useEffect, useState } from 'react';
+
+import debounce from 'lodash-es/debounce';
+
+export default function useScrollPosition<T extends HTMLElement>(ref?: MutableRefObject<T>) {
+  const [position, setPosition] = useState(0);
+
+  useEffect(() => {
+    let element: HTMLElement = document.body;
+    if (ref.current) {
+      element = ref.current;
+    }
+
+    const onScroll = debounce(() => setPosition(element.scrollTop), 10);
+
+    element.addEventListener('scroll', onScroll);
+
+    return () => element.removeEventListener('scroll', onScroll);
+  }, [ref]);
+
+  return position;
+}

--- a/frontend/translations/en.json
+++ b/frontend/translations/en.json
@@ -223,7 +223,11 @@
       "summary": "Summary",
       "terrestrial": "Terrestrial",
       "marine": "Marine",
-      "coming-soon": "Coming soon!"
+      "terrestrial-conservation-coverage": "Terrestrial Conservation Coverage",
+      "terrestrial-protected-percentage": "<b1>{percentage}</b1><b2>%</b2>",
+      "terrestrial-protected-area": "{protectedArea} km² out of {totalArea} km²",
+      "explore-terrestrial-conservation": "Explore Terrestrial Conservation",
+      "explore-marine-conservation": "Explore Marine Conservation"
     },
     "map-sidebar-layers-panel": {
       "layers": "Layers",


### PR DESCRIPTION
This PR does a few things:

- Display the terrestrial widgets in the sidebar
- Make sure the marine widgets only pull marine data
- Collapse/expand the sidebar's header based on the scroll position

## Testing instructions

- Use your local database as this PR is based on the terrestrial branch that has a different database schema
- Comment the LOCALAZY_CDN environment variable in your local .env to see the source strings (they are not uploaded to the CDN)
- The widgets will appear empty unless you link the stats models to the Environment model as we're filtering them by environment

## Tracking

[SKY30-388](https://vizzuality.atlassian.net/browse/SKY30-388)


[SKY30-388]: https://vizzuality.atlassian.net/browse/SKY30-388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ