### PR TITLE
[SKY30-450] Fishing protection level widget changes 

### DIFF
--- a/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/fishing-protection/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/fishing-protection/index.tsx
@@ -130,11 +130,17 @@ const FishingProtectionWidget: React.FC<FishingProtectionWidgetProps> = ({ locat
     if (!protectionLevelsData.length) return [];
 
     const parsedProtectionLevel = (label: string, protectionLevel, stats) => {
+      const totalAreaPercentage = (stats?.area / stats?.pct) * 100;
+
+      // There are circumstances in which pct is 0, which will cause the percentage calculation to be NaN.
+      // This is a safeguard so that if the data is unexpected, we don't display NaN on the screen.
+      if (isNaN(totalAreaPercentage)) return null;
+
       return {
         title: label,
         slug: protectionLevel.slug,
         background: FISHING_PROTECTION_CHART_COLORS[protectionLevel.slug],
-        totalArea: (stats?.area / stats?.pct) * 100,
+        totalArea: totalAreaPercentage,
         protectedArea: stats?.area,
         info: metadata?.info,
         sources: metadata?.sources,
@@ -158,11 +164,10 @@ const FishingProtectionWidget: React.FC<FishingProtectionWidgetProps> = ({ locat
       return parsedProtectionLevel(t('highly-protected-from-fishing'), protectionLevel, data);
     });
 
-    return parsedFishingProtectionLevelData ?? [];
+    return parsedFishingProtectionLevelData.filter(Boolean) ?? [];
   }, [t, protectionLevelsData, metadata]);
 
   const noData = !widgetChartData.length;
-
   const loading = isFetchingProtectionLevelsData;
 
   return (

--- a/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/fishing-protection/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/fishing-protection/index.tsx
@@ -167,7 +167,7 @@ const FishingProtectionWidget: React.FC<FishingProtectionWidgetProps> = ({ locat
 
   return (
     <Widget
-      title={t('fishing-protection')}
+      title={t('level-of-fishing-protection')}
       lastUpdated={protectionLevelsData[0]?.attributes?.updatedAt}
       noData={noData}
       loading={loading}

--- a/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/fishing-protection/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/fishing-protection/index.tsx
@@ -152,7 +152,12 @@ const FishingProtectionWidget: React.FC<FishingProtectionWidgetProps> = ({ locat
       loading={loading}
     >
       {widgetChartData.map((chartData) => (
-        <HorizontalBarChart key={chartData.slug} className="py-2" data={chartData} />
+        <HorizontalBarChart
+          key={chartData.slug}
+          className="py-2"
+          data={chartData}
+          showTarget={false}
+        />
       ))}
     </Widget>
   );

--- a/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/fishing-protection/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/fishing-protection/index.tsx
@@ -73,32 +73,6 @@ const FishingProtectionWidget: React.FC<FishingProtectionWidgetProps> = ({ locat
     }
   );
 
-  const { data: metadataWidget } = useGetDataInfos(
-    {
-      locale,
-      filters: {
-        slug: 'fishing-protection-widget',
-      },
-      populate: 'data_sources',
-    },
-    {
-      query: {
-        select: ({ data }) =>
-          data[0]
-            ? {
-                info: data[0].attributes.content,
-                sources: data[0].attributes?.data_sources?.data?.map(
-                  ({ attributes: { title, url } }) => ({
-                    title,
-                    url,
-                  })
-                ),
-              }
-            : undefined,
-      },
-    }
-  );
-
   const { data: metadata } = useGetDataInfos(
     {
       locale,
@@ -176,8 +150,6 @@ const FishingProtectionWidget: React.FC<FishingProtectionWidgetProps> = ({ locat
       lastUpdated={protectionLevelsData[0]?.attributes?.updatedAt}
       noData={noData}
       loading={loading}
-      info={metadataWidget?.info}
-      sources={metadataWidget?.sources}
     >
       {widgetChartData.map((chartData) => (
         <HorizontalBarChart key={chartData.slug} className="py-2" data={chartData} />

--- a/frontend/translations/en.json
+++ b/frontend/translations/en.json
@@ -216,7 +216,7 @@
       "administrative-boundary": "Administrative boundary",
       "national-level-contribution": "National level contribution",
       "global": "Global",
-      "fishing-protection": "Fishing Protection",
+      "level-of-fishing-protection": "Level of Fishing Protection",
       "highly-protected-from-fishing": "Highly protected from fishing"
     },
     "map-sidebar-layers-panel": {


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

This PR implements a few tweaks to the recently brought back Fishing Protection widget:  

- Renamed the widget to "Level of Fishing Protection" in the strings  
  - I've temporarily renamed the original string in Localazy as well, for QA purposes  
- Removed the widget's info button  
  - Deleted the respective API request as well for cleanup purposes  
- Removed the "30% target" orange indicator from the widget's entries  
- Added a check to prevent the display of `NaN`  
  - In this particular scenario, it happens because both area and pct in the stats are 0, so there was a division by 0. 
  - I've added a quick check for that, and when parsing data, we'll return `null` instead. The main function that parses the data will filter entries to eliminate `null` ones. In the particular bug scenario, it'll make the widget display _"Data not available"_ as per ticket entry, but it should still account for future changes (eg: more entries). 

### Testing instructions

- Visit the progress tracker  
- Pick "Bahrain" location   
  - Verify that there is no info button next to the Fishing widget's title  
  - Verify that the widget displays "Data not available"  
- Pick "France" location   
  - Verify that the widget displays correctly   
  - Verify that the chart entries do not have the "30% target" displayd  

### Feature relevant tickets

[SKY30-450](https://vizzuality.atlassian.net/browse/SKY30-450)

[SKY30-450]: https://vizzuality.atlassian.net/browse/SKY30-450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ