### PR TITLE
Change the “no data” message on the “Marine Conservation Protection Levels” widget

### DIFF
--- a/frontend/src/components/widget/index.tsx
+++ b/frontend/src/components/widget/index.tsx
@@ -27,7 +27,7 @@ type WidgetProps = {
   noData?: boolean;
   loading?: boolean;
   error?: boolean;
-  messageError?: ComponentProps<typeof NoData>['message'];
+  errorMessage?: ComponentProps<typeof NoData>['message'];
   info?: ComponentProps<typeof TooltipButton>['text'];
   sources?: ComponentProps<typeof TooltipButton>['sources'];
 };
@@ -45,7 +45,7 @@ const Widget: FCWithMessages<PropsWithChildren<WidgetProps>> = ({
   noData = false,
   loading = false,
   error = false,
-  messageError = undefined,
+  errorMessage = undefined,
   info,
   sources,
   children,
@@ -74,7 +74,7 @@ const Widget: FCWithMessages<PropsWithChildren<WidgetProps>> = ({
         )}
       </div>
       {loading && <Loading />}
-      {showNoData && <NoData error={error} message={messageError} />}
+      {showNoData && <NoData error={error} message={errorMessage} />}
       {!loading && !showNoData && <div>{children}</div>}
     </div>
   );

--- a/frontend/src/components/widget/index.tsx
+++ b/frontend/src/components/widget/index.tsx
@@ -25,6 +25,7 @@ type WidgetProps = {
   title?: string;
   lastUpdated?: string;
   noData?: boolean;
+  noDataMessage?: ComponentProps<typeof NoData>['message'];
   loading?: boolean;
   error?: boolean;
   errorMessage?: ComponentProps<typeof NoData>['message'];
@@ -43,6 +44,7 @@ const Widget: FCWithMessages<PropsWithChildren<WidgetProps>> = ({
   title,
   lastUpdated,
   noData = false,
+  noDataMessage = undefined,
   loading = false,
   error = false,
   errorMessage = undefined,
@@ -74,8 +76,9 @@ const Widget: FCWithMessages<PropsWithChildren<WidgetProps>> = ({
         )}
       </div>
       {loading && <Loading />}
-      {showNoData && <NoData error={error} message={errorMessage} />}
-      {!loading && !showNoData && <div>{children}</div>}
+      {!loading && error && <NoData error={error} message={errorMessage} />}
+      {!loading && !error && noData && <NoData error={error} message={noDataMessage} />}
+      {!loading && !error && !noData && <div>{children}</div>}
     </div>
   );
 };

--- a/frontend/src/components/widget/no-data/index.tsx
+++ b/frontend/src/components/widget/no-data/index.tsx
@@ -7,17 +7,16 @@ type NoDataProps = {
   message?: string;
 };
 
-const NoData: FCWithMessages<NoDataProps> = ({
-  error = false,
-  message = 'The current widget is not visible due to an error.',
-}) => {
+const NoData: FCWithMessages<NoDataProps> = ({ error = false, message }) => {
   const t = useTranslations('components.widget');
 
   return (
     <div className="flex flex-col gap-8 py-12 px-14 text-center md:px-10 md:py-14">
       <p className="text-xs">
-        {error && message}
-        {!error && t('no-data-available')}
+        {error && !message && t('not-visible-due-to-error')}
+        {error && !!message && message}
+        {!error && !message && t('no-data-available')}
+        {!error && !!message && message}
       </p>
     </div>
   );

--- a/frontend/src/containers/map/content/map/modelling/index.tsx
+++ b/frontend/src/containers/map/content/map/modelling/index.tsx
@@ -37,13 +37,13 @@ const Modelling = () => {
           setModellingState((prevState) => ({
             ...prevState,
             status: 'error',
-            messageError: req.response?.status === 400 ? req.response?.data.error : undefined,
+            errorMessage: req.response?.status === 400 ? req.response?.data.error : undefined,
           }));
         } else {
           setModellingState((prevState) => ({
             ...prevState,
             status: 'error',
-            messageError: undefined,
+            errorMessage: undefined,
           }));
         }
       },

--- a/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/protection-types/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/protection-types/index.tsx
@@ -116,6 +116,7 @@ const ProtectionTypesWidget: FCWithMessages<ProtectionTypesWidgetProps> = ({ loc
       title={t('marine-conservation-protection-levels')}
       lastUpdated={lastUpdated}
       noData={noData}
+      noDataMessage={t('not-assessed')}
       loading={loading}
     >
       {widgetChartData.map((chartData) => (

--- a/frontend/src/containers/map/sidebar/main-panel/panels/modelling/widget/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/panels/modelling/widget/index.tsx
@@ -78,7 +78,7 @@ const ModellingWidget: FCWithMessages = () => {
   const {
     status: modellingStatus,
     data: modellingData,
-    messageError,
+    errorMessage,
   } = useAtomValue(modellingAtom);
 
   // Tooltips with mapping
@@ -296,7 +296,7 @@ const ModellingWidget: FCWithMessages = () => {
       noData={!nationalLevelContributions}
       loading={loading}
       error={error}
-      messageError={messageError}
+      errorMessage={errorMessage}
     >
       <div className="flex flex-col">
         <div className={cn(DEFAULT_ENTRY_CLASSNAMES, 'flex justify-between border-t-0')}>

--- a/frontend/src/containers/map/store.ts
+++ b/frontend/src/containers/map/store.ts
@@ -33,10 +33,10 @@ export const modellingAtom = atomWithReset<{
   active: boolean;
   status: 'idle' | 'running' | 'success' | 'error';
   data: ModellingData;
-  messageError?: string;
+  errorMessage?: string;
 }>({
   active: false,
   status: 'idle',
   data: null,
-  messageError: undefined,
+  errorMessage: undefined,
 });

--- a/frontend/translations/en.json
+++ b/frontend/translations/en.json
@@ -334,7 +334,8 @@
     "widget": {
       "updated-on": "Updated on {date}",
       "loading-data": "Loading data...",
-      "no-data-available": "No data available"
+      "no-data-available": "No data available",
+      "not-visible-due-to-error": "The current widget is not visible due to an error"
     },
     "chart-conservation": {
       "30x30-target": "30x30 Target",

--- a/frontend/translations/en.json
+++ b/frontend/translations/en.json
@@ -228,7 +228,8 @@
       "terrestrial-protected-area": "{protectedArea} km² out of {totalArea} km²",
       "explore-terrestrial-conservation": "Explore Terrestrial Conservation",
       "explore-marine-conservation": "Explore Marine Conservation",
-      "terrestrial-existing-conservation": "Existing terrestrial conservation coverage"
+      "terrestrial-existing-conservation": "Existing terrestrial conservation coverage",
+      "not-assessed": "Not assessed"
     },
     "map-sidebar-layers-panel": {
       "layers": "Layers",


### PR DESCRIPTION
This PR replaces the default “No data available” message displayed on the “Marine Conservation Protection Levels” widget by “Not assessed” when there is no data available.

## Tracking

[SKY30-417](https://vizzuality.atlassian.net/browse/SKY30-417).

[SKY30-417]: https://vizzuality.atlassian.net/browse/SKY30-417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ