### PR TITLE
Replace the default “no data” widget message

### DIFF
--- a/frontend/src/components/widget/no-data/index.tsx
+++ b/frontend/src/components/widget/no-data/index.tsx
@@ -17,7 +17,7 @@ const NoData: FCWithMessages<NoDataProps> = ({
     <div className="flex flex-col gap-8 py-12 px-14 text-center md:px-10 md:py-14">
       <p className="text-xs">
         {error && message}
-        {!error && t('data-not-available')}
+        {!error && t('no-data-available')}
       </p>
     </div>
   );

--- a/frontend/translations/en.json
+++ b/frontend/translations/en.json
@@ -333,7 +333,7 @@
     "widget": {
       "updated-on": "Updated on {date}",
       "loading-data": "Loading data...",
-      "data-not-available": "Data not available"
+      "no-data-available": "No data available"
     },
     "chart-conservation": {
       "30x30-target": "30x30 Target",


### PR DESCRIPTION
This PR replaces the default “no data” message from “Data not available” to “No data available”.

## Tracking

[SKY30-431](https://vizzuality.atlassian.net/browse/SKY30-431)

[SKY30-431]: https://vizzuality.atlassian.net/browse/SKY30-431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ