### PR TITLE
[SKY30-452] Custom filtering when using the location input search in the sidebar

### DIFF
--- a/frontend/src/containers/map/sidebar/main-panel/location-selector/location-dropdown/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/location-selector/location-dropdown/index.tsx
@@ -51,8 +51,13 @@ const LocationDropdown: FCWithMessages<LocationDropdownProps> = ({
     }
   );
 
+  const handleFiltering = (value: string, search: string) => {
+    if (value.toLocaleLowerCase().includes(search.toLocaleLowerCase())) return 1;
+    return 0;
+  };
+
   return (
-    <Command label={t('search-country-region')} className={cn(className)}>
+    <Command label={t('search-country-region')} className={cn(className)} filter={handleFiltering}>
       <CommandInput placeholder={searchPlaceholder} />
       <CommandEmpty>{t('no-result')}</CommandEmpty>
       <CommandGroup className="mt-4 max-h-64 overflow-y-auto">


### PR DESCRIPTION
### Overview

When using the location selector on the sidebar, searching for a country returns unexpected results. 
An example is that, when the user types `uru` in the search box, looking for `Uruguay`, most of the search results return entries that do not have `uru` in the name. Uruguay does appear in the list, but the user will only see it if they scroll down. 

This PR provides a very simple, custom filtering function that is passed to the component (built with the `cmdk` library), in which it'll check whether the searched characters against the list (in a case insensitive way), so that the library will only show countries that _do_ include those characters. 

No external libraries added (eg: fusejs) as we don't have a need for fuzzy search at this point, and it'd introduce complexity, as we'd be overriding the default behavior of the library used. 

### Screenshots  

**Before:**  
![Screenshot 2024-10-07 at 13 53 06](https://github.com/user-attachments/assets/7e7a924a-78ae-4f30-8c59-3d7eb935f98e)

**After:**  
![Screenshot 2024-10-07 at 13 53 36](https://github.com/user-attachments/assets/8a4928f8-a859-47db-9472-00906d815578)



### Feature relevant tickets

[SKY30-452](https://vizzuality.atlassian.net/browse/SKY30-452)


[SKY30-452]: https://vizzuality.atlassian.net/browse/SKY30-452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ