### PR TITLE
Layers panel to display datasets grouped by environment - connect to Strapi

### DIFF
--- a/frontend/src/constants/datasets.ts
+++ b/frontend/src/constants/datasets.ts
@@ -1,0 +1,5 @@
+export const DATASETS = {
+  terrestrial: 'terrestrial',
+  marine: 'marine',
+  basemap: 'basemap',
+};

--- a/frontend/src/constants/environments.ts
+++ b/frontend/src/constants/environments.ts
@@ -1,5 +1,4 @@
-export const DATASETS = {
+export const ENVIRONMENTS = {
   terrestrial: 'terrestrial',
   marine: 'marine',
-  basemap: 'basemap',
 };

--- a/frontend/src/containers/map/sidebar/layers-panel/index.tsx
+++ b/frontend/src/containers/map/sidebar/layers-panel/index.tsx
@@ -174,6 +174,7 @@ const LayersPanel: FCWithMessages = (): JSX.Element => {
         loading={isFetchingDatasetsData}
         showDatasetsNames={false}
         showBottomBorder={false}
+        extraActiveLayers={labels ? 1 : 0}
       >
         {/*
           The labels toggle doesn't come from the basemap dataset and has slightly functionality implemented.

--- a/frontend/src/containers/map/sidebar/layers-panel/index.tsx
+++ b/frontend/src/containers/map/sidebar/layers-panel/index.tsx
@@ -116,13 +116,13 @@ const LayersPanel: FCWithMessages = (): JSX.Element => {
       <LayersGroup
         name={t('terrestrial-data')}
         datasets={datasets.terrestrial}
-        isOpen={['terrestrial'].includes(tab)}
+        isOpen={['summary', 'terrestrial'].includes(tab)}
         loading={isFetchingDatasetsData}
       />
       <LayersGroup
         name={t('marine-data')}
         datasets={datasets.marine}
-        isOpen={['marine'].includes(tab)}
+        isOpen={['summary', 'marine'].includes(tab)}
         loading={isFetchingDatasetsData}
       />
       <LayersGroup

--- a/frontend/src/containers/map/sidebar/layers-panel/index.tsx
+++ b/frontend/src/containers/map/sidebar/layers-panel/index.tsx
@@ -180,9 +180,14 @@ const LayersPanel: FCWithMessages = (): JSX.Element => {
           Not ideal, but given it's a one-off, we'll pass the entry as a child to be displayed alongside the
           other entries, much like in the previous implementation.
         */}
-        <li className="flex items-center justify-between">
-          <span className="flex gap-2">
-            <Switch id="labels-switch" checked={labels} onCheckedChange={handleLabelsChange} />
+        <li className="flex items-start justify-between">
+          <span className="flex items-start gap-2">
+            <Switch
+              id="labels-switch"
+              className="mt-px"
+              checked={labels}
+              onCheckedChange={handleLabelsChange}
+            />
             <Label htmlFor="labels-switch" className={SWITCH_LABEL_CLASSES}>
               {t('labels')}
             </Label>

--- a/frontend/src/containers/map/sidebar/layers-panel/index.tsx
+++ b/frontend/src/containers/map/sidebar/layers-panel/index.tsx
@@ -98,6 +98,25 @@ const LayersPanel: FCWithMessages = (): JSX.Element => {
     };
   }, [datasetsData]);
 
+  const defaultLayersIds = useMemo(() => {
+    const datasetsDefaultLayerIds = (datasets = []) => {
+      return datasets.reduce((acc, { attributes }) => {
+        const layersData = attributes?.layers?.data;
+        const defaultLayersIds = layersData.reduce(
+          (acc, { id, attributes }) => (attributes?.default ? [...acc, id] : acc),
+          []
+        );
+        return [...acc, ...defaultLayersIds];
+      }, []);
+    };
+
+    return {
+      terrestrial: datasetsDefaultLayerIds(datasets.terrestrial),
+      marine: datasetsDefaultLayerIds(datasets.marine),
+      basemap: datasetsDefaultLayerIds(datasets.basemap),
+    };
+  }, [datasets]);
+
   const handleLabelsChange = useCallback(
     (active: Parameters<ComponentProps<typeof Switch>['onCheckedChange']>[0]) => {
       setMapSettings((prev) => ({

--- a/frontend/src/containers/map/sidebar/layers-panel/layers-group/index.tsx
+++ b/frontend/src/containers/map/sidebar/layers-panel/layers-group/index.tsx
@@ -136,10 +136,11 @@ const LayersGroup: FCWithMessages<LayersGroupProps> = ({
                     const metadata = layer?.attributes?.metadata;
 
                     return (
-                      <li key={layer.id} className="flex items-center justify-between">
-                        <span className="flex gap-2">
+                      <li key={layer.id} className="flex items-start justify-between">
+                        <span className="flex items-start gap-2">
                           <Switch
                             id={`${layer.id}-switch`}
+                            className="mt-px"
                             checked={isActive}
                             onCheckedChange={onCheckedChange}
                           />
@@ -148,7 +149,7 @@ const LayersGroup: FCWithMessages<LayersGroupProps> = ({
                           </Label>
                         </span>
                         {metadata?.description && (
-                          <TooltipButton className="-my-1" text={metadata?.description} />
+                          <TooltipButton className="mt-px" text={metadata?.description} />
                         )}
                       </li>
                     );

--- a/frontend/src/containers/map/sidebar/layers-panel/layers-group/index.tsx
+++ b/frontend/src/containers/map/sidebar/layers-panel/layers-group/index.tsx
@@ -120,8 +120,8 @@ const LayersGroup: FCWithMessages<LayersGroupProps> = ({
         className={cn(COLLAPSIBLE_CONTENT_CLASSES, { 'border-b': showBottomBorder })}
       >
         <div className="space-y-4 divide-y divide-dashed divide-black">
-          {loading && <span>{t('loading')}</span>}
-          {noData && <span>{t('no-data')}</span>}
+          {loading && <span className="font-mono text-xs">{t('loading')}</span>}
+          {noData && <span className="font-mono text-xs">{t('no-data-available')}</span>}
           {datasets?.map((dataset) => {
             return (
               <div key={dataset.id} className="[&:not(:first-child)]:pt-3">

--- a/frontend/src/containers/map/sidebar/layers-panel/layers-group/index.tsx
+++ b/frontend/src/containers/map/sidebar/layers-panel/layers-group/index.tsx
@@ -30,6 +30,8 @@ type LayersGroupProps = PropsWithChildren<{
   showBottomBorder?: boolean;
   isOpen?: boolean;
   loading?: boolean;
+  // Number of extra active layers for this group
+  extraActiveLayers?: number;
 }>;
 
 const LayersGroup: FCWithMessages<LayersGroupProps> = ({
@@ -39,6 +41,7 @@ const LayersGroup: FCWithMessages<LayersGroupProps> = ({
   showBottomBorder = true,
   isOpen = true,
   loading = true,
+  extraActiveLayers = 0,
   children,
 }): JSX.Element => {
   const [open, setOpen] = useState(isOpen);
@@ -55,8 +58,11 @@ const LayersGroup: FCWithMessages<LayersGroupProps> = ({
   }, [datasets]);
 
   const numActiveDatasetsLayers = useMemo(() => {
-    return datasetsLayersIds?.filter((id) => activeLayers?.includes(id))?.length || 0;
-  }, [datasetsLayersIds, activeLayers]);
+    return (
+      (datasetsLayersIds?.filter((id) => activeLayers?.includes(id))?.length ?? 0) +
+      extraActiveLayers
+    );
+  }, [datasetsLayersIds, activeLayers, extraActiveLayers]);
 
   const onToggleLayer = useCallback(
     (layerId: LayerResponseDataObject['id'], isActive: boolean) => {

--- a/frontend/translations/en.json
+++ b/frontend/translations/en.json
@@ -238,7 +238,7 @@
       "marine-data": "Marine Data",
       "terrestrial-data": "Terrestrial Data",
       "loading": "Loading data...",
-      "no-data": "Data not available"
+      "no-data-available": "No data available"
     },
     "map": {
       "loading": "Loading...",


### PR DESCRIPTION
### Overview

This PR connects the layers panel to the actual data coming from Strapi, and displays layers by environment type based on which environment a layer is currently assigned to. 

Changes were planned to be unobtrusive, and confined to the `LayersPanel` component that fetches datasets; it fetches datasets basically the same way as before, though it does populate the `environment` for the `layers` content type, and then processes them for display. The `LayersGroup` component is then kept unchanged. 

**Logic:**  
- Datasets are pulled in the same way as before, but now `environment` is populated as well  
- Datasets are parsed into 3 groups for display  
  - Basemap (which is environment agnostic, but it is defined as a dataset group in Strapi)  
    - On the display, we are injecting the `Labels` as a toggle, hence the separate processing, same as before
  - Marine + Terrestrial groups (datasets that are not Basemap)  
    - For each environment (Marine, Terrestrial), we parse the dataset, in the following way:  
      - For each dataset, we filter the corresponding layers by the environment  
      - If a dataset does not have any layers (after filtering by environment), the dataset itself is filtered out  

**Result:**  

This allows for correct display, isolation of the dataset/layer parsing for display, and some flexibility:  

- We don't have to create different datasets with the same name for both Maritime and Terrestrial groups;
  - We have an environment agnostic dataset, it is the layers themselves that can belong to an environment  
  - It will allow the FE to display a specific layer for both Terrestrial and Maritime groups in the future  
    - Right now this is not possible due to the relationships established in the BE/Strapi, but the FE would allow this if it were to change  

**Caveats:**  

A layer _must_ have an environment associated on Strapi, or it won't be displayed as a toggle anywhere. We're filtering layers by environment, so if one doesn't have one associated, then the FE cannot display it (though the application will not break. The map, however, will display it. This does mean we could potentially display map layers that do not have corresponding toggles on the panel. 
  

### Testing instructions

1. Test environment / staging (with current data):    
  - Simply change a layer's environment from "Maritime"  to "Terrestrial" (on Strapi)  
    - It should automatically be displayed as a Terrestrial layer, dataset group name should display as well  
2. Locally with (local test data):  
  - Create a new test layer  
  - Create a new "Terrestrial" dataset
    _in order to test a new header entry_  
  - Assign the relationship and dataset  
  - It should be displayed (eg: Screenshot below)

### Screenshot

![Screenshot 2024-10-08 at 13 43 57](https://github.com/user-attachments/assets/00e77448-ca03-4b3b-ad66-b4889eddbddf)


### Feature relevant tickets

[SKY30-444](https://vizzuality.atlassian.net/browse/SKY30-444)


[SKY30-444]: https://vizzuality.atlassian.net/browse/SKY30-444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ