### PR TITLE
Hide habitats with no associated data in the habitat widget

### DIFF
--- a/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/habitat/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/habitat/index.tsx
@@ -130,10 +130,12 @@ const HabitatWidget: FCWithMessages<HabitatWidgetProps> = ({ location }) => {
             };
           });
 
-          return parsedData.sort((d1, d2) => {
-            const keys = Object.keys(HABITAT_CHART_COLORS);
-            return keys.indexOf(d1.slug) - keys.indexOf(d2.slug);
-          });
+          return parsedData
+            .sort((d1, d2) => {
+              const keys = Object.keys(HABITAT_CHART_COLORS);
+              return keys.indexOf(d1.slug) - keys.indexOf(d2.slug);
+            })
+            .filter(({ totalArea }) => totalArea !== 0);
         },
         placeholderData: [],
         refetchOnWindowFocus: false,

--- a/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/summary-widgets.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/summary-widgets.tsx
@@ -34,6 +34,10 @@ const SummaryWidgets: FCWithMessages = () => {
     }
   );
 
+  if (!locationData) {
+    return null;
+  }
+
   return (
     <div
       className={cn({


### PR DESCRIPTION
This PR makes sure to hide habitats with no associated data in the “Proportion of Habitat within Protected and Conserved Areas” widget. There is also a fix for a crash when changing location while viewing the Summary tab.

## Tracking

[SKY30-482](https://vizzuality.atlassian.net/browse/SKY30-482)

[SKY30-482]: https://vizzuality.atlassian.net/browse/SKY30-482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ