### PR TITLE
Only show relevant layers in the legend

### DIFF
--- a/frontend/src/containers/map/content/map/layers-toolbox/legend/index.tsx
+++ b/frontend/src/containers/map/content/map/layers-toolbox/legend/index.tsx
@@ -13,6 +13,7 @@ import {
   useSyncMapLayerSettings,
   useSyncMapLayers,
 } from '@/containers/map/content/map/sync-settings';
+import { useSyncMapContentSettings } from '@/containers/map/sync-settings';
 import { cn } from '@/lib/classnames';
 import ArrowDownIcon from '@/styles/icons/arrow-down.svg';
 import ArrowTopIcon from '@/styles/icons/arrow-top.svg';
@@ -20,7 +21,10 @@ import CloseIcon from '@/styles/icons/close.svg';
 import OpacityIcon from '@/styles/icons/opacity.svg';
 import { FCWithMessages } from '@/types';
 import { useGetLayers } from '@/types/generated/layer';
-import { LayerResponseDataObject } from '@/types/generated/strapi.schemas';
+import {
+  LayerListResponseDataItem,
+  LayerResponseDataObject,
+} from '@/types/generated/strapi.schemas';
 import { LayerTyped } from '@/types/layers';
 
 import LegendItem from './item';
@@ -31,12 +35,38 @@ const Legend: FCWithMessages = () => {
 
   const [activeLayers, setMapLayers] = useSyncMapLayers();
   const [layerSettings, setLayerSettings] = useSyncMapLayerSettings();
+  const [{ tab }] = useSyncMapContentSettings();
 
-  const layersQuery = useGetLayers(
+  const layersQuery = useGetLayers<LayerListResponseDataItem[]>(
     {
       locale,
       sort: 'title:asc',
-      populate: 'legend_config,legend_config.items',
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      fields: ['title'],
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      populate: {
+        legend_config: {
+          populate: {
+            items: true,
+          },
+        },
+        environment: {
+          fields: ['slug'],
+        },
+      },
+      filters: {
+        ...(tab !== 'summary'
+          ? {
+              environment: {
+                slug: {
+                  $in: tab,
+                },
+              },
+            }
+          : {}),
+      },
     },
     {
       query: {


### PR DESCRIPTION
This PR makes sure to only show relevant layers in the legend based on the active sidebar tab.

## Tracking

[SKY30-480](https://vizzuality.atlassian.net/browse/SKY30-480)

[SKY30-480]: https://vizzuality.atlassian.net/browse/SKY30-480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ