### PR TITLE
Apply feedback to the tables

### DIFF
--- a/cms/src/api/pa/controllers/pa.ts
+++ b/cms/src/api/pa/controllers/pa.ts
@@ -4,4 +4,72 @@
 
 import { factories } from '@strapi/strapi'
 
-export default factories.createCoreController('api::pa.pa');
+export default factories.createCoreController('api::pa.pa', ({ strapi }) => ({
+  async find(ctx) {
+    if (ctx.query['keep-if-children-match']) {
+      // In addition to the controller's default behavior, we also want to keep the rows for which
+      // there is at least one child that matches the filters. For this, we'll use the `children`
+      // and `parent` fields.
+
+      // First, we get the list of all the parents (no pagination) for which at least one child
+      // matches the filters. No sorting.
+      const { parent, ...filtersWithoutParentProperty } = ctx.query.filters ?? {};
+
+      const parentIds = (await strapi.entityService.findMany('api::pa.pa', {
+        fields: ['id'],
+        populate: {
+          parent: {
+            fields: ['id'],
+          },
+        },
+        filters: {
+          $and: [
+            {
+              parent: {
+                name: {
+                  $null: false,
+                },
+              },
+            },
+            filtersWithoutParentProperty,
+          ],
+        },
+        limit: -1,
+      }) as { id: number; parent: { id: number } }[]).map((d) => d.parent.id);
+
+      const uniqueParentIds = [...new Set(parentIds)];
+
+      // Then, we get the list of all parents that match the initial request or the ones for which
+      // children match, using the list of ids `uniqueParentIds`.
+      return await super.find({
+        ...ctx,
+        query: {
+          ...ctx.query,
+          filters: {
+            $and: [
+              {
+                parent: {
+                  name: {
+                    $null: true,
+                  },
+                },
+              },
+              {
+                $or: [
+                  filtersWithoutParentProperty,
+                  {
+                    id: {
+                      $in: uniqueParentIds,
+                    },
+                  },
+                ],
+              },
+            ],
+          }
+        },
+      });
+    } else {
+      return await super.find(ctx);
+    }
+  }
+}));

--- a/frontend/src/containers/map/content/details/table/helpers.ts
+++ b/frontend/src/containers/map/content/details/table/helpers.ts
@@ -1,7 +1,13 @@
 import { formatPercentage, formatKM } from '@/lib/utils/formats';
 
-const percentage = (locale: string, value: number) => {
-  return formatPercentage(locale, value, { displayPercentageSign: false });
+const percentage = (
+  locale: string,
+  value: number,
+  options: { displayPercentageSign?: boolean; displayZeroValue?: boolean } = {
+    displayPercentageSign: false,
+  }
+) => {
+  return formatPercentage(locale, value, options);
 };
 
 const area = (locale: string, value: number) => {

--- a/frontend/src/containers/map/content/details/tables/national-highseas/hooks.tsx
+++ b/frontend/src/containers/map/content/details/tables/national-highseas/hooks.tsx
@@ -344,12 +344,14 @@ export const useColumns = (
         accessorKey: 'data_source.title',
         header: ({ column }) => (
           <HeaderItem>
-            <FiltersButton
-              field="data_source.slug"
-              options={filtersOptions.dataSource}
-              values={filters['data_source.slug'] ?? []}
-              onChange={(field, values) => onChangeFilters({ ...filters, [field]: values })}
-            />
+            {environment !== 'terrestrial' && (
+              <FiltersButton
+                field="data_source.slug"
+                options={filtersOptions.dataSource}
+                values={filters['data_source.slug'] ?? []}
+                onChange={(field, values) => onChangeFilters({ ...filters, [field]: values })}
+              />
+            )}
             {t('data-source')}
             <TooltipButton column={column} tooltips={tooltips} />
           </HeaderItem>

--- a/frontend/src/containers/map/content/details/tables/national-highseas/hooks.tsx
+++ b/frontend/src/containers/map/content/details/tables/national-highseas/hooks.tsx
@@ -305,9 +305,12 @@ export const useColumns = (
         ),
         cell: ({ row }) => {
           const { coverage: value } = row.original;
-          if (!value) return <>&mdash;</>;
+          if (value === undefined || value === null) return <>&mdash;</>;
 
-          const formattedCoverage = cellFormatter.percentage(locale, value);
+          const formattedCoverage = cellFormatter.percentage(locale, value, {
+            displayZeroValue: false,
+            displayPercentageSign: false,
+          });
 
           return (
             <span className="text-4xl font-bold">

--- a/frontend/src/lib/utils/formats.ts
+++ b/frontend/src/lib/utils/formats.ts
@@ -1,9 +1,16 @@
 export function formatPercentage(
   locale: string,
   value: number,
-  options?: Intl.NumberFormatOptions & { displayPercentageSign?: boolean }
+  options?: Intl.NumberFormatOptions & {
+    displayPercentageSign?: boolean;
+    displayZeroValue?: boolean;
+  }
 ) {
-  const { displayPercentageSign = true, ...intlNumberFormatOptions } = options || {};
+  const {
+    displayPercentageSign = true,
+    displayZeroValue = true,
+    ...intlNumberFormatOptions
+  } = options || {};
 
   const v = Intl.NumberFormat(locale === 'en' ? 'en-US' : locale, {
     minimumFractionDigits: 1,
@@ -12,7 +19,7 @@ export function formatPercentage(
     ...intlNumberFormatOptions,
   });
 
-  if (value < 0.1 && value > 0) {
+  if (value < 0.1 && (!displayZeroValue || (displayZeroValue && value > 0))) {
     return `<${v.format(0.1)}`;
   }
 


### PR DESCRIPTION
This PR applies internal feedback after the implementation of the paginated tables and the addition of the terrestrial data. In particular, this PR does the following:

- Make sure that the “Coverage” values are displayed as “<0.1%” if equal to 0 in Strapi
- Remove the “Data Source” filter when viewing the Terrestrial tab
- Fix a crash due to a too long request URL by moving some logic to a custom Strapi controller (see the new `keep-if-children-match` query parameter)