### PR TITLE
Update visuals of the Conservation Coverage widget

### DIFF
--- a/frontend/src/components/charts/conservation-chart/legend/index.tsx
+++ b/frontend/src/components/charts/conservation-chart/legend/index.tsx
@@ -1,20 +1,67 @@
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 
+import TooltipButton from '@/components/tooltip-button';
 import { FCWithMessages } from '@/types';
+import { useGetDataInfos } from '@/types/generated/data-info';
 
-const ChartLegend: FCWithMessages = () => {
+interface ChartLegendProps {
+  displayTarget?: boolean;
+  target?: number;
+  targetYear?: number;
+  tooltipSlug: string;
+}
+
+const ChartLegend: FCWithMessages<ChartLegendProps> = ({
+  displayTarget,
+  target,
+  targetYear,
+  tooltipSlug,
+}) => {
   const t = useTranslations('components.chart-conservation');
+  const locale = useLocale();
+
+  const { data: dataInfo } = useGetDataInfos(
+    {
+      locale,
+      filters: {
+        slug: tooltipSlug,
+      },
+    },
+    {
+      query: {
+        select: ({ data }) => data?.[0],
+        placeholderData: { data: [] },
+      },
+    }
+  );
 
   return (
-    <div className="mt-2 ml-8 flex justify-between gap-3">
+    <div className="mt-2 ml-8 flex flex-wrap justify-between gap-3">
       <span className="inline-flex items-center gap-3">
-        <span className="block h-[2px] w-10 border-b-2 border-violet"></span>
+        <span className="block w-10 border-b border-violet"></span>
         <span>{t('historical-trend')}</span>
       </span>
       <span className="inline-flex items-center gap-3">
-        <span className="block h-[2px] w-10 border-b-2 border-dashed border-violet"></span>
+        <span className="block w-10 border-b border-dashed border-violet"></span>
         <span>{t('future-projection')}</span>
       </span>
+      {displayTarget && (
+        <span className="inline-flex w-full items-center gap-3">
+          <span className="block w-10 border-b border-orange"></span>
+          <span>
+            {t.rich('target-xx-by', {
+              target,
+              year: targetYear,
+            })}
+            <TooltipButton
+              text={dataInfo?.attributes.content
+                .replace('{target}', `${target}`)
+                .replace('{target_year}', `${targetYear}`)}
+              className="align-bottom hover:bg-transparent"
+            />
+          </span>
+        </span>
+      )}
     </div>
   );
 };

--- a/frontend/translations/en.json
+++ b/frontend/translations/en.json
@@ -348,7 +348,7 @@
       "historical-trend": "Historical Trend",
       "future-projection": "Future Projection",
       "historical": "Historical",
-      "percentage-target": "{target}% target"
+      "target-xx-by": "Target: {target}% by {year}"
     },
     "chart-horizontal-bar": {
       "marine-protected-percentage": "{percentage}<b>%</b>",


### PR DESCRIPTION
This PR updates the visuals of the Conservation Coverage widget in order to avoid text overlap.

## Tracking

[SKY30-489](https://vizzuality.atlassian.net/browse/SKY30-489)

[SKY30-489]: https://vizzuality.atlassian.net/browse/SKY30-489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ